### PR TITLE
Fixes https://github.com/welovewordpress/SublimePhpTidy/issues/15.

### DIFF
--- a/phptidy.php
+++ b/phptidy.php
@@ -1203,9 +1203,22 @@ function fix_docblock_format(&$tokens) {
 			if ($line=="") continue;
 			if ($line!="/**" and $line!="*/") {
 
-				// Add stars where missing
-				if (substr($line, 0, 1)!="*") $line = "* ".$line;
-				elseif ($line!="*" and substr($line, 0, 2)!="* ") $line = "* ".substr($line, 1);
+				// test for single-line comments
+				$docblock_start = '/**';
+				$docblock_end = '*/';
+				if ( substr( $line, 0, 3 ) === $docblock_start and
+					substr_compare($line, $docblock_end, -strlen($docblock_end), strlen($docblock_end)) === 0
+					) {
+					return;
+				} else {
+					// Add stars where missing
+					if ( substr( $line, 0, 1 )!="*" ) {
+					 $line = "* ".$line;
+					}
+					elseif( $line!="*" and substr( $line, 0, 2 )!="* " ) {
+					 $line = "* ".substr( $line, 1 );
+					}
+				}
 
 				// Strip empty lines at the beginning
 				if (!$comments_started) {

--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -1250,9 +1250,22 @@ function fix_docblock_format( &$tokens ) {
 			if ( $line=="" ) continue;
 			if ( $line!="/**" and $line!="*/" ) {
 
-				// Add stars where missing
-				if ( substr( $line, 0, 1 )!="*" ) $line = "* ".$line;
-				elseif ( $line!="*" and substr( $line, 0, 2 )!="* " ) $line = "* ".substr( $line, 1 );
+				// test for single-line comments
+				$docblock_start = '/**';
+				$docblock_end = '*/';
+				if ( substr( $line, 0, 3 ) === $docblock_start and
+					substr_compare($line, $docblock_end, -strlen($docblock_end), strlen($docblock_end)) === 0
+					) {
+					return;
+				} else {
+					// Add stars where missing
+					if ( substr( $line, 0, 1 )!="*" ) {
+					 $line = "* ".$line;
+					}
+					elseif( $line!="*" and substr( $line, 0, 2 )!="* " ) {
+					 $line = "* ".substr( $line, 1 );
+					}
+				}
 
 				// Strip empty lines at the beginning
 				if ( !$comments_started ) {
@@ -2229,7 +2242,7 @@ function add_file_docblock( &$tokens ) {
 
 
 /**
- * Adds funktion DocBlocks where missing
+ * Adds function DocBlocks where missing
  *
  * @param array   $tokens (reference)
  */


### PR DESCRIPTION
Add check for single-line DocBlocks and return early if we're in one.
