### PR TITLE
Allow custom configurations using the built-in settings.

### DIFF
--- a/.phptidy-config.php
+++ b/.phptidy-config.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Custom configuration for PSR2 style.
+ */
+$curly_brace_newline = array(T_CLASS, T_FUNCTION);
+
+$default_author = "Morgan Estes <morgan.estes@gmail.com>";
+
+// Enable the single cleanup functions
+$fix_token_case = true;
+$fix_builtin_functions_case = true;
+$replace_inline_tabs = true;
+$replace_phptags = true;
+$replace_shell_comments = true;
+$fix_statement_brackets = false;
+$fix_separation_whitespace = true;
+$fix_comma_space = true;
+$add_file_docblock = true;
+$add_function_docblocks = true;
+$add_doctags = true;
+$fix_docblock_format = true;
+$fix_docblock_space = true;
+$add_blank_lines = false;
+$indent = true;

--- a/phptidy.php
+++ b/phptidy.php
@@ -104,8 +104,8 @@ $indent = true;
 ///////////// END OF DEFAULT CONFIGURATION ////////////////
 
 
-define('CONFIGFILE', "./.phptidy-config.php");
-define('CACHEFILE', "./.phptidy-cache");
+define('CONFIGFILE', dirname(__FILE__) . "/.phptidy-config.php");
+define('CACHEFILE', dirname(__FILE__) . "/.phptidy-cache");
 
 
 error_reporting(E_ALL);

--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -108,8 +108,8 @@ $indent = true;
 ///////////// END OF DEFAULT CONFIGURATION ////////////////
 
 
-define( 'CONFIGFILE', "./.phptidy-config.php" );
-define( 'CACHEFILE', "./.phptidy-cache" );
+define( 'CONFIGFILE', dirname(__FILE__) . "/.wp-phptidy-config.php" );
+define( 'CACHEFILE', dirname(__FILE__) . "/.phptidy-cache" );
 
 
 error_reporting( E_ALL );


### PR DESCRIPTION
The script automatically looks for a config file, but inside
Sublime Text 2, it wasn't pulling from the right place. This just
changes it to look in the same folder as the script (inside the plugin
folder).

This should only be used for the non-WP `phptidy.php` script, because
the plugin already handles the custom WordPress stylings.
