### PR TITLE
Fix whitespace for square brackets, operators, and DocBlocks params

### DIFF
--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -150,20 +150,20 @@ switch ( $command ) {
 	case "help":
 	case "--help":
 	case "-h":
-	usage();
-	exit;
+		usage();
+		exit;
 	case "suffix":
 	case "replace":
 	case "diff":
 	case "source":
 	case "files":
 	case "tokens":
-	break;
+		break;
 	default:
-	echo "Unknown command: '" . $command . "'\n";
+		echo "Unknown command: '" . $command . "'\n";
 	case "":
-	usage();
-	exit( 1 );
+		usage();
+		exit( 1 );
 }
 
 // Get options
@@ -172,8 +172,8 @@ foreach ( $options as $option ) {
 	switch ( $option ) {
 		case "-v":
 		case "--verbose":
-		$verbose = true;
-		continue 2;
+			$verbose = true;
+			continue 2;
 	}
 	echo "Unknown option: '" . $option . "'\n";
 	usage();
@@ -319,47 +319,47 @@ foreach ( $files as $file ) {
 	switch ( $command ) {
 		case "suffix":
 
-		$newfile = $file . ".phptidy.php";
-		if ( ! file_put_contents( $newfile, $source ) ) {
-			echo "Error: The file '" . $newfile . "' could not be saved.\n";
-			exit( 1 );
-		}
-		verbose( "  " . $newfile . " saved.\n" );
+			$newfile = $file . ".phptidy.php";
+			if ( ! file_put_contents( $newfile, $source ) ) {
+				echo "Error: The file '" . $newfile . "' could not be saved.\n";
+				exit( 1 );
+			}
+			verbose( "  " . $newfile . " saved.\n" );
 
-		break;
+			break;
 		case "replace":
 
-		$backupfile = dirname( $file ) . ( dirname( $file )?"/":"" ) . "." . basename( $file ) . ".phptidybak~";
-		if ( ! copy( $file, $backupfile ) ) {
-			echo "Error: The file '" . $backupfile . "' could not be saved.\n";
-			exit( 1 );
-		}
-		if ( ! file_put_contents( $file, $source ) ) {
-			echo "Error: The file '" . $file . "' could not be overwritten.\n";
-			exit( 1 );
-		}
-		verbose( "  replaced.\n" );
-		++$replaced;
+			$backupfile = dirname( $file ) . ( dirname( $file )?"/":"" ) . "." . basename( $file ) . ".phptidybak~";
+			if ( ! copy( $file, $backupfile ) ) {
+				echo "Error: The file '" . $backupfile . "' could not be saved.\n";
+				exit( 1 );
+			}
+			if ( ! file_put_contents( $file, $source ) ) {
+				echo "Error: The file '" . $file . "' could not be overwritten.\n";
+				exit( 1 );
+			}
+			verbose( "  replaced.\n" );
+			++$replaced;
 
-		// Write new md5sum into cache
-		$cache['md5sums'][ $file ] = md5( $source );
+			// Write new md5sum into cache
+			$cache['md5sums'][ $file ] = md5( $source );
 
-		break;
+			break;
 		case "diff":
 
-		$tmpfile = "/tmp/tmp.phptidy.php";
-		if ( ! file_put_contents( $tmpfile, $source ) ) {
-			echo "Error: The temporary file '" . $tmpfile . "' could not be saved.\n";
-			exit( 1 );
-		}
-		system( "echo -ne '\\033[01;34m'; diff -u " . $file . " " . $tmpfile . " 2>&1; echo -ne '\\033[00m'" );
+			$tmpfile = "/tmp/tmp.phptidy.php";
+			if ( ! file_put_contents( $tmpfile, $source ) ) {
+				echo "Error: The temporary file '" . $tmpfile . "' could not be saved.\n";
+				exit( 1 );
+			}
+			system( "echo -ne '\\033[01;34m'; diff -u " . $file . " " . $tmpfile . " 2>&1; echo -ne '\\033[00m'" );
 
-		break;
+			break;
 		case "source":
 
-		echo $source;
+			echo $source;
 
-		break;
+			break;
 	}
 
 }
@@ -870,66 +870,66 @@ function replace_phptags( &$tokens ) {
 		switch ( $token[0] ) {
 			case T_OPEN_TAG:
 
-			// The open tag is already the right one
-			if ( rtrim( $token[1] ) == $GLOBALS['open_tag'] ) continue;
+				// The open tag is already the right one
+				if ( rtrim( $token[1] ) == $GLOBALS['open_tag'] ) continue;
 
-			// Collect following whitespace
-			preg_match( "/\s*$/", $token[1], $matches );
-			$whitespace = $matches[0];
-			if ( $tokens[ $key + 1 ][0] === T_WHITESPACE ) {
-				$whitespace .= $tokens[ $key + 1 ][1];
-				array_splice( $tokens, $key + 1, 1 );
-			}
-
-			if ( $GLOBALS['open_tag'] == "<?" ) {
-
-				// Short open tags have the following whitespace in a seperate token
-				array_splice( $tokens, $key, 1, array(
-						array( T_OPEN_TAG, $GLOBALS['open_tag'] ),
-						array( T_WHITESPACE, $whitespace )
-					) );
-
-			} else {
-
-				// Long open tags have the following whitespace included in the token string
-				switch ( strlen( $whitespace ) ) {
-					case 0:
-					// Add an additional space if no whitespace is found
-					$whitespace = " ";
-					case 1:
-					// Use the one found space or newline
-					$tokens[ $key ][1] = $GLOBALS['open_tag'] . $whitespace;
-					break;
-					default:
-					// Use the first space or newline for the open tag and append the rest of the whitespace as a seperate token
-					array_splice( $tokens, $key, 1, array(
-							array( T_OPEN_TAG, $GLOBALS['open_tag'] . substr( $whitespace, 0, 1 ) ),
-							array( T_WHITESPACE, substr( $whitespace, 1 ) )
-						) );
+				// Collect following whitespace
+				preg_match( "/\s*$/", $token[1], $matches );
+				$whitespace = $matches[0];
+				if ( $tokens[ $key + 1 ][0] === T_WHITESPACE ) {
+					$whitespace .= $tokens[ $key + 1 ][1];
+					array_splice( $tokens, $key + 1, 1 );
 				}
 
-			}
+				if ( $GLOBALS['open_tag'] == "<?" ) {
 
-			break;
+					// Short open tags have the following whitespace in a seperate token
+					array_splice( $tokens, $key, 1, array(
+							array( T_OPEN_TAG, $GLOBALS['open_tag'] ),
+							array( T_WHITESPACE, $whitespace )
+						) );
+
+				} else {
+
+					// Long open tags have the following whitespace included in the token string
+					switch ( strlen( $whitespace ) ) {
+						case 0:
+							// Add an additional space if no whitespace is found
+							$whitespace = " ";
+						case 1:
+							// Use the one found space or newline
+							$tokens[ $key ][1] = $GLOBALS['open_tag'] . $whitespace;
+							break;
+						default:
+							// Use the first space or newline for the open tag and append the rest of the whitespace as a seperate token
+							array_splice( $tokens, $key, 1, array(
+									array( T_OPEN_TAG, $GLOBALS['open_tag'] . substr( $whitespace, 0, 1 ) ),
+									array( T_WHITESPACE, substr( $whitespace, 1 ) )
+								) );
+					}
+
+				}
+
+				break;
 			case T_OPEN_TAG_WITH_ECHO:
 
-			// If we use short tags we also accept the echo tags
-			if ( $GLOBALS['open_tag'] == "<?" ) continue;
+				// If we use short tags we also accept the echo tags
+				if ( $GLOBALS['open_tag'] == "<?" ) continue;
 
-			if ( $tokens[ $key + 1 ][0] === T_WHITESPACE ) {
-				// If there is already whitespace following we only replace the open tag
-				array_splice( $tokens, $key, 1, array(
-						array( T_OPEN_TAG, $GLOBALS['open_tag'] . " " ),
-						array( T_ECHO, "echo" )
-					) );
-			} else {
-				// If there is no whitespace following we add one space
-				array_splice( $tokens, $key, 1, array(
-						array( T_OPEN_TAG, $GLOBALS['open_tag'] . " " ),
-						array( T_ECHO, "echo" ),
-						array( T_WHITESPACE, " " )
-					) );
-			}
+				if ( $tokens[ $key + 1 ][0] === T_WHITESPACE ) {
+					// If there is already whitespace following we only replace the open tag
+					array_splice( $tokens, $key, 1, array(
+							array( T_OPEN_TAG, $GLOBALS['open_tag'] . " " ),
+							array( T_ECHO, "echo" )
+						) );
+				} else {
+					// If there is no whitespace following we add one space
+					array_splice( $tokens, $key, 1, array(
+							array( T_OPEN_TAG, $GLOBALS['open_tag'] . " " ),
+							array( T_ECHO, "echo" ),
+							array( T_WHITESPACE, " " )
+						) );
+				}
 
 		}
 
@@ -1073,76 +1073,76 @@ function fix_separation_whitespace( &$tokens ) {
 
 			switch ( $token[0] ) {
 				case T_CLASS:
-				// Class definition
-				if (
-					isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
-					isset( $tokens[ $key + 2 ][0] ) and $tokens[ $key + 2 ][0] === T_STRING
-				) {
-					// Exactly 1 space between 'class' and the class name
-					$tokens[ $key + 1 ][1] = " ";
-					// Exactly 1 space between the class name and the opening curly bracket
-					if ( $tokens[ $key + 3 ] === "{" ) {
-						// Insert an additional space or newline before the bracket
-						array_splice( $tokens, $key + 3, 0, array(
-								array( T_WHITESPACE, separation_whitespace( T_CLASS ) )
-							) );
-					} elseif (
-						isset( $tokens[ $key + 3 ][0] ) and $tokens[ $key + 3 ][0] === T_WHITESPACE and
-						isset( $tokens[ $key + 4 ] ) and $tokens[ $key + 4 ] === "{"
+					// Class definition
+					if (
+						isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
+						isset( $tokens[ $key + 2 ][0] ) and $tokens[ $key + 2 ][0] === T_STRING
 					) {
-						// Set the existing whitespace before the bracket to exactly one space or a newline
-						$tokens[ $key + 3 ][1] = separation_whitespace( T_CLASS );
+						// Exactly 1 space between 'class' and the class name
+						$tokens[ $key + 1 ][1] = " ";
+						// Exactly 1 space between the class name and the opening curly bracket
+						if ( $tokens[ $key + 3 ] === "{" ) {
+							// Insert an additional space or newline before the bracket
+							array_splice( $tokens, $key + 3, 0, array(
+									array( T_WHITESPACE, separation_whitespace( T_CLASS ) )
+								) );
+						} elseif (
+							isset( $tokens[ $key + 3 ][0] ) and $tokens[ $key + 3 ][0] === T_WHITESPACE and
+							isset( $tokens[ $key + 4 ] ) and $tokens[ $key + 4 ] === "{"
+						) {
+							// Set the existing whitespace before the bracket to exactly one space or a newline
+							$tokens[ $key + 3 ][1] = separation_whitespace( T_CLASS );
+						}
 					}
-				}
-				break;
+					break;
 				case T_FUNCTION:
-				// Function definition
-				if (
-					isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
-					isset( $tokens[ $key + 2 ][0] ) and $tokens[ $key + 2 ][0] === T_STRING
-				) {
-					// Exactly 1 Space between 'function' and the function name
-					$tokens[ $key + 1 ][1] = " ";
-					// No whitespace between function name and opening round bracket
-					if ( isset( $tokens[ $key + 3 ][0] ) and $tokens[ $key + 3 ][0] === T_WHITESPACE ) {
-						// Remove the whitespace
-						array_splice( $tokens, $key + 3, 1 );
+					// Function definition
+					if (
+						isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
+						isset( $tokens[ $key + 2 ][0] ) and $tokens[ $key + 2 ][0] === T_STRING
+					) {
+						// Exactly 1 Space between 'function' and the function name
+						$tokens[ $key + 1 ][1] = " ";
+						// No whitespace between function name and opening round bracket
+						if ( isset( $tokens[ $key + 3 ][0] ) and $tokens[ $key + 3 ][0] === T_WHITESPACE ) {
+							// Remove the whitespace
+							array_splice( $tokens, $key + 3, 1 );
+						}
 					}
-				}
-				break;
+					break;
 				case T_IF:
 				case T_ELSEIF:
 				case T_FOR:
 				case T_FOREACH:
 				case T_WHILE:
 				case T_SWITCH:
-				// At least 1 space between a statement and a opening round bracket
-				if ( $tokens[ $key + 1 ] === "(" ) {
-					// Insert an additional space or newline before the bracket
-					array_splice( $tokens, $key + 1, 0, array(
-							array( T_WHITESPACE, separation_whitespace( T_SWITCH ) ),
-						) );
-				}
-				break;
+					// At least 1 space between a statement and a opening round bracket
+					if ( $tokens[ $key + 1 ] === "(" ) {
+						// Insert an additional space or newline before the bracket
+						array_splice( $tokens, $key + 1, 0, array(
+								array( T_WHITESPACE, separation_whitespace( T_SWITCH ) ),
+							) );
+					}
+					break;
 				case T_ELSE:
 				case T_DO:
-				// Exactly 1 space between a command and a opening curly bracket
-				if ( $tokens[ $key + 1 ] === "{" ) {
-					// Insert an additional space or newline before the bracket
-					array_splice( $tokens, $key + 1, 0, array(
-							array( T_WHITESPACE, separation_whitespace( T_DO ) ),
-						) );
-				} elseif (
-					isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
-					isset( $tokens[ $key + 2 ] ) and $tokens[ $key + 2 ] === "{"
-				) {
-					// Set the existing whitespace before the bracket to exactly one space or a newline
-					$tokens[ $key + 1 ][1] = separation_whitespace( T_DO );
-				}
-				break;
+					// Exactly 1 space between a command and a opening curly bracket
+					if ( $tokens[ $key + 1 ] === "{" ) {
+						// Insert an additional space or newline before the bracket
+						array_splice( $tokens, $key + 1, 0, array(
+								array( T_WHITESPACE, separation_whitespace( T_DO ) ),
+							) );
+					} elseif (
+						isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
+						isset( $tokens[ $key + 2 ] ) and $tokens[ $key + 2 ] === "{"
+					) {
+						// Set the existing whitespace before the bracket to exactly one space or a newline
+						$tokens[ $key + 1 ][1] = separation_whitespace( T_DO );
+					}
+					break;
 				default:
-				// Do not set $control_structure if the token is no control structure
-				continue 2;
+					// Do not set $control_structure if the token is no control structure
+					continue 2;
 			}
 
 			$control_structure = $token[0];
@@ -1463,23 +1463,23 @@ function fix_square_bracket_space( &$tokens ) {
 		$u = $key;
 		switch ( $type ) {
 			case  T_VARIABLE:
-			// If the next token is not a whitespace token.
-			if ( isset( $tokens[ $key + 1 ][0] ) && ( T_WHITESPACE !== $tokens[ $key + 1 ][0] ) ) {
-				// Add a space after the bracket, before a variable.
-				array_splice( $tokens, $key + 1, 0, array( array( T_WHITESPACE, ' ' ) ) );
-			}
-			break;
+				// If the next token is not a whitespace token.
+				if ( isset( $tokens[ $key + 1 ][0] ) && ( T_WHITESPACE !== $tokens[ $key + 1 ][0] ) ) {
+					// Add a space after the bracket, before a variable.
+					array_splice( $tokens, $key + 1, 0, array( array( T_WHITESPACE, ' ' ) ) );
+				}
+				break;
 			case  'EMPTY_SQUARE_BRACKETS':
 			case  T_LNUMBER:
 			case  T_CONSTANT_ENCAPSED_STRING:
-			// Remove leading whitespace for empty brackets, and numbers and strings.
-			do {
-				if ( isset( $tokens[ $u ][0] ) && ( T_WHITESPACE === $tokens[ $u ][0] ) ) {
-					unset( $tokens[ $u ] );
-				}
-				++$u;
-			} while ( isset( $tokens[ $u ] ) and ( T_WHITESPACE === $tokens[ $u ][0] ) );
-			break;
+				// Remove leading whitespace for empty brackets, and numbers and strings.
+				do {
+					if ( isset( $tokens[ $u ][0] ) && ( T_WHITESPACE === $tokens[ $u ][0] ) ) {
+						unset( $tokens[ $u ] );
+					}
+					++$u;
+				} while ( isset( $tokens[ $u ] ) and ( T_WHITESPACE === $tokens[ $u ][0] ) );
+				break;
 		}
 	}
 
@@ -1520,21 +1520,21 @@ function fix_square_bracket_space( &$tokens ) {
 
 					case  T_LNUMBER:
 					case  T_CONSTANT_ENCAPSED_STRING:
-					// Remove trailing whitespace for numbers and strings before the bracket.
-					do {
-						if ( isset( $tokens[ $u ][0] ) && ( T_WHITESPACE === $tokens[ $u ][0] ) ) {
-							unset( $tokens[ $u ] );
-						}
-						--$u;
-					} while ( isset( $tokens[ $u ] ) and ( T_WHITESPACE === $tokens[ $u ][0] ) );
-					break;
+						// Remove trailing whitespace for numbers and strings before the bracket.
+						do {
+							if ( isset( $tokens[ $u ][0] ) && ( T_WHITESPACE === $tokens[ $u ][0] ) ) {
+								unset( $tokens[ $u ] );
+							}
+							--$u;
+						} while ( isset( $tokens[ $u ] ) and ( T_WHITESPACE === $tokens[ $u ][0] ) );
+						break;
 					case  T_VARIABLE:
-					// If the previous token is not a whitespace token.
-					if ( isset( $tokens[ $k - 1 ][0] ) && ( T_WHITESPACE !== $tokens[ $k - 1 ][0] ) ) {
-						// Add a space before the bracket.
-						array_splice( $tokens, $k, 0, array( array( T_WHITESPACE, ' ' ) ) );
-					}
-					break;
+						// If the previous token is not a whitespace token.
+						if ( isset( $tokens[ $k - 1 ][0] ) && ( T_WHITESPACE !== $tokens[ $k - 1 ][0] ) ) {
+							// Add a space before the bracket.
+							array_splice( $tokens, $k, 0, array( array( T_WHITESPACE, ' ' ) ) );
+						}
+						break;
 				}
 
 				// Processed the closing bracket.
@@ -2342,26 +2342,26 @@ function add_doctags_to_doc_comment( $text, $tagname, $tags ) {
 					// Add new line
 					switch ( $tagname ) {
 						case "param":
-						if ( empty( $tag[1] ) ) $tag[1] = "unknown";
-						$newtext .= "* @param " . $tag[1] . " " . $tag[0] . ( isset( $tag[2] )?" " . $tag[2]:"" ) . "\n";
-						break;
+							if ( empty( $tag[1] ) ) $tag[1] = "unknown";
+							$newtext .= "* @param " . $tag[1] . " " . $tag[0] . ( isset( $tag[2] )?" " . $tag[2]:"" ) . "\n";
+							break;
 						case "uses":
-						$newtext .= "* @uses " . $tag[0] . "()\n";
-						break;
+							$newtext .= "* @uses " . $tag[0] . "()\n";
+							break;
 						case "return":
-						$newtext .= "* @return unknown\n";
-						break;
+							$newtext .= "* @return unknown\n";
+							break;
 						case "author":
-						if ( $GLOBALS['default_author'] ) {
-							$newtext .= "* @author " . $GLOBALS['default_author'] . "\n";
-						}
-						break;
+							if ( $GLOBALS['default_author'] ) {
+								$newtext .= "* @author " . $GLOBALS['default_author'] . "\n";
+							}
+							break;
 						case "package":
-						$newtext .= "* @package " . $GLOBALS['default_package'] . "\n";
-						break;
+							$newtext .= "* @package " . $GLOBALS['default_package'] . "\n";
+							break;
 						case "see":
-						$newtext .= "* @see " . $tag[0] . "\n";
-						break;
+							$newtext .= "* @see " . $tag[0] . "\n";
+							break;
 					}
 
 				}
@@ -2419,108 +2419,108 @@ function collect_doctags( &$tokens ) {
 
 			switch ( $token[0] ) {
 				case T_FUNCTION:
-				// Find function definitions
+					// Find function definitions
 
-				$round_braces_count = 0;
+					$round_braces_count = 0;
 
-				$k = $key + 1;
+					$k = $key + 1;
 
-				if ( is_string( $tokens[ $k ] ) or $tokens[ $k ][0] !== T_WHITESPACE ) {
-					possible_syntax_error( $tokens, $k, "No whitespace found between function keyword and function name" );
-					break;
-				}
-
-				++$k;
-
-				// & before function name
-				if ( $tokens[ $k ] === "&" ) ++$k;
-
-				if ( is_string( $tokens[ $k ] ) or $tokens[ $k ][0] !== T_STRING ) {
-					possible_syntax_error( $tokens, $k, "No string for function name found" );
-					break;
-				}
-
-				$function = $tokens[ $k ][1];
-				$function_declarations[] = $key;
-
-				// Collect param-doctags
-				$k += 2;
-				// Area between round brackets
-				$reference = false;
-				while ( ( $tokens[ $k ] != ")" or $round_braces_count ) and $k < count( $tokens ) ) {
-					if ( is_string( $tokens[ $k ] ) ) {
-						if     ( $tokens[ $k ] === "(" ) ++$round_braces_count;
-						elseif ( $tokens[ $k ] === ")" ) --$round_braces_count;
-						elseif ( $tokens[ $k ] === "&" ) $reference = true;
-					} else {
-						$typehint = false;
-						if (
-							$tokens[ $k ][0] === T_VARIABLE
-						) {
-							$typehint = "";
-						} elseif (
-							$tokens[ $k ][0] === T_ARRAY and
-							isset( $tokens[ $k + 1 ][0] ) and $tokens[ $k + 1 ][0] === T_WHITESPACE and
-							isset( $tokens[ $k + 2 ][0] ) and $tokens[ $k + 2 ][0] === T_VARIABLE
-						) {
-							$k += 2;
-							$typehint = "array";
-						} elseif (
-							$tokens[ $k ][0] === T_STRING and
-							isset( $tokens[ $k + 1 ][0] ) and $tokens[ $k + 1 ][0] === T_WHITESPACE and
-							isset( $tokens[ $k + 2 ][0] ) and $tokens[ $k + 2 ][0] === T_VARIABLE
-						) {
-							$k += 2;
-							$typehint = "object";
-						}
-						if ( $typehint !== false ) {
-							$comments = array();
-							if (
-								( isset( $tokens[ $k + 1 ] ) and $tokens[ $k + 1 ] === "=" ) or (
-									isset( $tokens[ $k + 1 ][0] ) and $tokens[ $k + 1 ][0] === T_WHITESPACE and
-									isset( $tokens[ $k + 2 ] ) and $tokens[ $k + 2 ] === "="
-								)
-							) {
-								$comments[] = "optional";
-							}
-							if ( $reference ) {
-								$comments[] = "reference";
-								$reference = false;
-							}
-							if ( count( $comments ) ) {
-								$comment = "(" . join( ", ", $comments ) . ")";
-							} else {
-								$comment = "";
-							}
-							$paramtags[ $function ][] = array( $tokens[ $k ][1], $typehint, $comment );
-						}
+					if ( is_string( $tokens[ $k ] ) or $tokens[ $k ][0] !== T_WHITESPACE ) {
+						possible_syntax_error( $tokens, $k, "No whitespace found between function keyword and function name" );
+						break;
 					}
+
 					++$k;
-				}
-				break;
+
+					// & before function name
+					if ( $tokens[ $k ] === "&" ) ++$k;
+
+					if ( is_string( $tokens[ $k ] ) or $tokens[ $k ][0] !== T_STRING ) {
+						possible_syntax_error( $tokens, $k, "No string for function name found" );
+						break;
+					}
+
+					$function = $tokens[ $k ][1];
+					$function_declarations[] = $key;
+
+					// Collect param-doctags
+					$k += 2;
+					// Area between round brackets
+					$reference = false;
+					while ( ( $tokens[ $k ] != ")" or $round_braces_count ) and $k < count( $tokens ) ) {
+						if ( is_string( $tokens[ $k ] ) ) {
+							if     ( $tokens[ $k ] === "(" ) ++$round_braces_count;
+							elseif ( $tokens[ $k ] === ")" ) --$round_braces_count;
+							elseif ( $tokens[ $k ] === "&" ) $reference = true;
+						} else {
+							$typehint = false;
+							if (
+								$tokens[ $k ][0] === T_VARIABLE
+							) {
+								$typehint = "";
+							} elseif (
+								$tokens[ $k ][0] === T_ARRAY and
+								isset( $tokens[ $k + 1 ][0] ) and $tokens[ $k + 1 ][0] === T_WHITESPACE and
+								isset( $tokens[ $k + 2 ][0] ) and $tokens[ $k + 2 ][0] === T_VARIABLE
+							) {
+								$k += 2;
+								$typehint = "array";
+							} elseif (
+								$tokens[ $k ][0] === T_STRING and
+								isset( $tokens[ $k + 1 ][0] ) and $tokens[ $k + 1 ][0] === T_WHITESPACE and
+								isset( $tokens[ $k + 2 ][0] ) and $tokens[ $k + 2 ][0] === T_VARIABLE
+							) {
+								$k += 2;
+								$typehint = "object";
+							}
+							if ( $typehint !== false ) {
+								$comments = array();
+								if (
+									( isset( $tokens[ $k + 1 ] ) and $tokens[ $k + 1 ] === "=" ) or (
+										isset( $tokens[ $k + 1 ][0] ) and $tokens[ $k + 1 ][0] === T_WHITESPACE and
+										isset( $tokens[ $k + 2 ] ) and $tokens[ $k + 2 ] === "="
+									)
+								) {
+									$comments[] = "optional";
+								}
+								if ( $reference ) {
+									$comments[] = "reference";
+									$reference = false;
+								}
+								if ( count( $comments ) ) {
+									$comment = "(" . join( ", ", $comments ) . ")";
+								} else {
+									$comment = "";
+								}
+								$paramtags[ $function ][] = array( $tokens[ $k ][1], $typehint, $comment );
+							}
+						}
+						++$k;
+					}
+					break;
 				case T_CURLY_OPEN:
 				case T_DOLLAR_OPEN_CURLY_BRACES:
-				++$curly_braces_count;
-				break;
+					++$curly_braces_count;
+					break;
 				case T_STRING:
-				// Find function calls
-				if (
-					$tokens[ $key + 1 ] === "(" and
-					! in_array( $key - 2, $function_declarations ) and
-					in_array( $token[1], $GLOBALS['functions'] )
-				) {
-					$usestags[ $function ][] = array( $token[1] );
-				}
-				break;
+					// Find function calls
+					if (
+						$tokens[ $key + 1 ] === "(" and
+						! in_array( $key - 2, $function_declarations ) and
+						in_array( $token[1], $GLOBALS['functions'] )
+					) {
+						$usestags[ $function ][] = array( $token[1] );
+					}
+					break;
 				case T_RETURN:
-				// Find returns
-				if (
-					$tokens[ $key + 1 ] != ";" and
-					$tokens[ $key + 2 ] != ";"
-				) {
-					$returntags[ $function ][] = array( "" );
-				}
-				break;
+					// Find returns
+					if (
+						$tokens[ $key + 1 ] != ";" and
+						$tokens[ $key + 2 ] != ";"
+					) {
+						$returntags[ $function ][] = array( "" );
+					}
+					break;
 			}
 
 		}
@@ -2551,72 +2551,72 @@ function add_file_docblock( &$tokens ) {
 	switch ( $tokens[0][0] ) {
 		case T_OPEN_TAG:
 
-		if ( $GLOBALS['open_tag'] == "<?" ) {
-			if ( $tokens[1][0] === T_WHITESPACE and $tokens[2][0] === T_DOC_COMMENT ) return;
-			// Insert new file docblock after open tag
-			array_splice( $tokens, 0, 1, array(
-					array( T_OPEN_TAG, "<?" ),
-					array( T_WHITESPACE, "\n" ),
-					array( T_DOC_COMMENT, $default_file_docblock ),
-					array( T_WHITESPACE, "\n" )
-				) );
-		} else {
-			if ( $tokens[1][0] === T_DOC_COMMENT ) return;
-			// Insert new file docblock after open tag
-			array_splice( $tokens, 0, 1, array(
-					array( T_OPEN_TAG, $GLOBALS['open_tag'] . "\n" ),
-					array( T_DOC_COMMENT, $default_file_docblock ),
-					array( T_WHITESPACE, "\n" )
-				) );
-		}
+			if ( $GLOBALS['open_tag'] == "<?" ) {
+				if ( $tokens[1][0] === T_WHITESPACE and $tokens[2][0] === T_DOC_COMMENT ) return;
+				// Insert new file docblock after open tag
+				array_splice( $tokens, 0, 1, array(
+						array( T_OPEN_TAG, "<?" ),
+						array( T_WHITESPACE, "\n" ),
+						array( T_DOC_COMMENT, $default_file_docblock ),
+						array( T_WHITESPACE, "\n" )
+					) );
+			} else {
+				if ( $tokens[1][0] === T_DOC_COMMENT ) return;
+				// Insert new file docblock after open tag
+				array_splice( $tokens, 0, 1, array(
+						array( T_OPEN_TAG, $GLOBALS['open_tag'] . "\n" ),
+						array( T_DOC_COMMENT, $default_file_docblock ),
+						array( T_WHITESPACE, "\n" )
+					) );
+			}
 
-		break;
+			break;
 		case T_INLINE_HTML:
 
-		if ( preg_match( "/^#!\//", $tokens[0][1] ) ) {
-			// File begins with "shebang"-line for direct execution
+			if ( preg_match( "/^#!\//", $tokens[0][1] ) ) {
+				// File begins with "shebang"-line for direct execution
 
-			if ( $GLOBALS['open_tag'] == "<?" ) {
-				if ( $tokens[2][0] === T_WHITESPACE and $tokens[3][0] === T_DOC_COMMENT ) return;
-				// Insert new file docblock after open tag
-				array_splice( $tokens, 1, 1, array(
-						array( T_OPEN_TAG, "<?" ),
-						array( T_WHITESPACE, "\n" ),
-						array( T_DOC_COMMENT, $default_file_docblock ),
-						array( T_WHITESPACE, "\n" )
-					) );
+				if ( $GLOBALS['open_tag'] == "<?" ) {
+					if ( $tokens[2][0] === T_WHITESPACE and $tokens[3][0] === T_DOC_COMMENT ) return;
+					// Insert new file docblock after open tag
+					array_splice( $tokens, 1, 1, array(
+							array( T_OPEN_TAG, "<?" ),
+							array( T_WHITESPACE, "\n" ),
+							array( T_DOC_COMMENT, $default_file_docblock ),
+							array( T_WHITESPACE, "\n" )
+						) );
+				} else {
+					if ( $tokens[2][0] === T_DOC_COMMENT ) return;
+					// Insert new file docblock after open tag
+					array_splice( $tokens, 1, 1, array(
+							array( T_OPEN_TAG, $GLOBALS['open_tag'] . "\n" ),
+							array( T_DOC_COMMENT, $default_file_docblock ),
+							array( T_WHITESPACE, "\n" )
+						) );
+				}
+
 			} else {
-				if ( $tokens[2][0] === T_DOC_COMMENT ) return;
-				// Insert new file docblock after open tag
-				array_splice( $tokens, 1, 1, array(
-						array( T_OPEN_TAG, $GLOBALS['open_tag'] . "\n" ),
-						array( T_DOC_COMMENT, $default_file_docblock ),
-						array( T_WHITESPACE, "\n" )
-					) );
+				// File begins with HTML
+
+				// Insert new file docblock in open and close tags at the beginning of the file
+				if ( $GLOBALS['open_tag'] == "<?" ) {
+					array_splice( $tokens, 0, 0, array(
+							array( T_OPEN_TAG, "<?" ),
+							array( T_WHITESPACE, "\n" ),
+							array( T_DOC_COMMENT, $default_file_docblock ),
+							array( T_WHITESPACE, "\n\n\n" ),
+							array( T_CLOSE_TAG, "?>\n" )
+						) );
+				} else {
+					array_splice( $tokens, 0, 0, array(
+							array( T_OPEN_TAG, $GLOBALS['open_tag'] . "\n" ),
+							array( T_DOC_COMMENT, $default_file_docblock ),
+							array( T_WHITESPACE, "\n\n\n" ),
+							array( T_CLOSE_TAG, "?>\n" )
+						) );
+				}
+
 			}
-
-		} else {
-			// File begins with HTML
-
-			// Insert new file docblock in open and close tags at the beginning of the file
-			if ( $GLOBALS['open_tag'] == "<?" ) {
-				array_splice( $tokens, 0, 0, array(
-						array( T_OPEN_TAG, "<?" ),
-						array( T_WHITESPACE, "\n" ),
-						array( T_DOC_COMMENT, $default_file_docblock ),
-						array( T_WHITESPACE, "\n\n\n" ),
-						array( T_CLOSE_TAG, "?>\n" )
-					) );
-			} else {
-				array_splice( $tokens, 0, 0, array(
-						array( T_OPEN_TAG, $GLOBALS['open_tag'] . "\n" ),
-						array( T_DOC_COMMENT, $default_file_docblock ),
-						array( T_WHITESPACE, "\n\n\n" ),
-						array( T_CLOSE_TAG, "?>\n" )
-					) );
-			}
-
-		}
 
 	}
 

--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -1785,14 +1785,22 @@ function indent( &$tokens ) {
 	// Level of round brackets
 	$round_braces_count = 0;
 
+	$extra_indentation = 0;
+
 	$round_brace_opener = false;
 	$round_braces_control = 0;
+
+	// Array to remember what control structure was last opened
+	$control_structure_type = array();
 
 	// Number of opened control structures without curly brackets inside of a level of curly brackets
 	$control_structure = array( 0 );
 
 	$heredoc_started = false;
 	$trinity_started = false;
+
+
+	$tokens_with_blocks = array( T_IF, T_ELSE, T_ELSEIF, T_SWITCH, T_CLASS, T_INTERFACE, T_FUNCTION, T_DO, T_WHILE, T_CATCH, T_TRY, T_FOREACH );
 
 	foreach ( $tokens as $key => &$token ) {
 
@@ -1818,7 +1826,13 @@ function indent( &$tokens ) {
 					$token[0] !== T_WHITESPACE or
 					strpos( $token[1], "\n" ) !== false
 				) {
-					if     ( $tokens[ $key + 1 ] === "}" ) --$curly_braces_count;
+					if ( $tokens[ $key + 1 ] === "}" ) {
+						--$curly_braces_count;
+						// Remove the last token from out stack
+						if ( array_pop( $control_structure_type ) == T_SWITCH ) {
+							--$extra_indentation;
+						}
+					}
 					elseif ( $tokens[ $key + 1 ] === ")" ) --$round_braces_count;
 				}
 			} else {
@@ -1828,7 +1842,13 @@ function indent( &$tokens ) {
 					$tokens[ $key + 1 ][0] === T_WHITESPACE and
 					strpos( $tokens[ $key + 1 ][1], "\n" ) === false
 				) {
-					if     ( $tokens[ $key + 2 ] === "}" ) --$curly_braces_count;
+					if ( $tokens[ $key + 2 ] === "}" ) {
+						--$curly_braces_count;
+						// Remove the last token from out stack
+						if ( array_pop( $control_structure_type ) == T_SWITCH ) {
+							--$extra_indentation;
+						}
+					}
 					elseif ( $tokens[ $key + 2 ] === ")" ) --$round_braces_count;
 				}
 			}
@@ -1884,11 +1904,16 @@ function indent( &$tokens ) {
 			// After a command or a set of commands a control structure is closed.
 			if ( ! empty( $control_structure[ $curly_braces_count ] ) ) --$control_structure[ $curly_braces_count ];
 
+			if ( $token === "}" ) {
+
+			}
+
 		} else {
 			indent_text(
 				$tokens,
 				$key,
 				$curly_braces_count,
+				$extra_indentation,
 				$round_braces_count,
 				$control_structure,
 				( is_array( $token ) and $token[0] === T_DOC_COMMENT ),
@@ -1908,10 +1933,31 @@ function indent( &$tokens ) {
 			// If a curly bracket occurs, no command without brackets can follow.
 			if ( ! empty( $control_structure[ $curly_braces_count ] ) ) --$control_structure[ $curly_braces_count ];
 			++$curly_braces_count;
+
 			// Inside of the new level of curly brackets it starts with no control structure.
 			$control_structure[ $curly_braces_count ] = 0;
+
+			// Find the last taken that can have a block and add it to the stack
+			for ( $i = $key; $tokens > 0; $i-- ) {
+				if ( isset( $tokens[ $i ][0] ) ) {
+					if ( in_array( $tokens[ $i ][0], $tokens_with_blocks ) ) {
+						$control_structure_type[] = $tokens[ $i ][0];
+						break;
+					}
+				}
+			}
+
+			if ( end( $control_structure_type ) == T_SWITCH ) {
+				++$extra_indentation;
+			}
 		}
 
+		// Debugging code
+		/*echo "\nStack:\n";
+		foreach ($control_structure_type as $index => $structure) {
+			echo $index.". ";
+			echo token_name($structure)."\n";
+		} */
 	}
 
 }
@@ -1928,7 +1974,7 @@ function indent( &$tokens ) {
  * @param boolean $docblock
  * @param boolean $trinity_started    (reference)
  */
-function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, $control_structure, $docblock, &$trinity_started ) {
+function indent_text( &$tokens, $key, $curly_braces_count, $extra_indentation, $round_braces_count, $control_structure, $docblock, &$trinity_started ) {
 
 	if ( is_string( $tokens[ $key ] ) ) {
 		$text =& $tokens[ $key ];
@@ -1940,29 +1986,30 @@ function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, 
 		if ( strpos( $text, "\n" ) === false ) return;
 		if ( token_is_taboo( $tokens[ $key ] ) ) return;
 	}
-
 	$indent = $curly_braces_count + $round_braces_count;
 	for ( $i = 0; $i <= $curly_braces_count; ++$i ) {
 		$indent += $control_structure[ $i ];
 	}
 
+	$indent += $extra_indentation;
+
 	// One indentation level less for "switch ... case ... default"
-	// if (
-	//  isset( $tokens[ $key+1] ) and
-	//  is_array( $tokens[ $key+1] ) and (
-	//   $tokens[ $key+1][0] === T_CASE or
-	//   $tokens[ $key+1][0] === T_DEFAULT or (
-	//    isset( $tokens[ $key+2] ) and
-	//    is_array( $tokens[ $key+2] ) and (
-	//     $tokens[ $key+2][0] === T_CASE or
-	//     $tokens[ $key+2][0] === T_DEFAULT
-	//    ) and
-	//    // T_WHITESPACE without \n first
-	//    $tokens[ $key+1][0] === T_WHITESPACE and
-	//    strpos( $tokens[ $key+1][1], "\n" )===false
-	//   )
-	//  )
-	// ) --$indent;
+	if (
+		isset( $tokens[ $key + 1 ] ) and
+		is_array( $tokens[ $key + 1 ] ) and (
+			$tokens[ $key + 1 ][0] === T_CASE or
+			$tokens[ $key + 1 ][0] === T_DEFAULT or (
+				isset( $tokens[ $key + 2 ] ) and
+				is_array( $tokens[ $key + 2 ] ) and (
+					$tokens[ $key + 2 ][0] === T_CASE or
+					$tokens[ $key + 2 ][0] === T_DEFAULT
+				) and
+				// T_WHITESPACE without \n first
+				$tokens[ $key + 1 ][0] === T_WHITESPACE and
+				strpos( $tokens[ $key + 1 ][1], "\n" ) === false
+			)
+		)
+	) --$indent;
 
 	// One indentation level less for an opening curly brace on a seperate line
 	if (
@@ -2029,7 +2076,9 @@ function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, 
 			".",
 			array( T_CONCAT_EQUAL, ".=" ),
 			// type
-			array( T_INSTANCEOF, "instanceof" )
+			array( T_INSTANCEOF, "instanceof" ),
+			// object
+			array( T_OBJECT_OPERATOR, "->" )
 		);
 
 		if (

--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -110,13 +110,13 @@ $indent = true;
 ///////////// END OF DEFAULT CONFIGURATION ////////////////
 
 
-define( 'CONFIGFILE', dirname(__FILE__) . "/.wp-phptidy-config.php" );
-define( 'CACHEFILE', dirname(__FILE__) . "/.phptidy-cache" );
+define( 'CONFIGFILE', dirname( __FILE__ ) . "/.wp-phptidy-config.php" );
+define( 'CACHEFILE', dirname( __FILE__ ) . "/.phptidy-cache" );
 
 
 error_reporting( E_ALL );
 
-if ( !version_compare( phpversion(), "5.0", ">=" ) ) {
+if ( ! version_compare( phpversion(), "5.0", ">=" ) ) {
 	echo "Error: phptidy requires PHP 5 or newer.\n";
 	exit( 1 );
 }
@@ -132,12 +132,12 @@ $command = "";
 $files = array();
 $options = array();
 foreach ( $_SERVER['argv'] as $key => $value ) {
-	if ( $key==0 ) continue;
-	if ( $key==1 ) {
+	if ( $key == 0 ) continue;
+	if ( $key == 1 ) {
 		$command = $value;
 		continue;
 	}
-	if ( substr( $value, 0, 1 )=="-" ) {
+	if ( substr( $value, 0, 1 ) == "-" ) {
 		$options[] = $value;
 	} else {
 		$files[] = $value;
@@ -146,21 +146,21 @@ foreach ( $_SERVER['argv'] as $key => $value ) {
 
 // Get command
 switch ( $command ) {
-case "help":
-case "--help":
-case "-h":
+	case "help":
+	case "--help":
+	case "-h":
 	usage();
 	exit;
-case "suffix":
-case "replace":
-case "diff":
-case "source":
-case "files":
-case "tokens":
+	case "suffix":
+	case "replace":
+	case "diff":
+	case "source":
+	case "files":
+	case "tokens":
 	break;
-default:
-	echo "Unknown command: '".$command."'\n";
-case "":
+	default:
+	echo "Unknown command: '" . $command . "'\n";
+	case "":
 	usage();
 	exit( 1 );
 }
@@ -169,27 +169,27 @@ case "":
 $verbose = false;
 foreach ( $options as $option ) {
 	switch ( $option ) {
-	case "-v":
-	case "--verbose":
+		case "-v":
+		case "--verbose":
 		$verbose = true;
 		continue 2;
 	}
-	echo "Unknown option: '".$option."'\n";
+	echo "Unknown option: '" . $option . "'\n";
 	usage();
 	exit( 1 );
 }
 
 // Load config file
 if ( file_exists( CONFIGFILE ) ) {
-	verbose( "Using configuration file ".CONFIGFILE."\n" );
+	verbose( "Using configuration file " . CONFIGFILE . "\n" );
 	require CONFIGFILE;
 } else {
 	verbose( "Running without configuration file\n" );
 }
 
 // Files from config file
-if ( !count( $files ) ) {
-	if ( !count( $project_files ) ) {
+if ( ! count( $files ) ) {
+	if ( ! count( $project_files ) ) {
 		echo "Error: No files supplied on commandline and also no project files specified in config file\n";
 		exit( 1 );
 	}
@@ -202,34 +202,34 @@ if ( !count( $files ) ) {
 foreach ( $project_files_excludes as $file_exclude ) {
 	if (
 		( $key = array_search( $file_exclude, $files ) ) !== false
-	) unset( $files[$key] );
+	) unset( $files[ $key ] );
 }
 
 // Check files
 foreach ( $files as $key => $file ) {
 	// Ignore backups and results from phptidy
 	if (
-		substr( $file, -12 )==".phptidybak~" or
-		substr( $file, -12 )==".phptidy.php"
+		substr( $file, - 12 ) == ".phptidybak~" or
+		substr( $file, - 12 ) == ".phptidy.php"
 	) {
-		unset( $files[$key] );
+		unset( $files[ $key ] );
 		continue;
 	}
-	if ( !is_readable( $file ) or !is_file( $file ) ) {
-		echo "Error: File '".$file."' does not exist or is not readable\n";
+	if ( ! is_readable( $file ) or ! is_file( $file ) ) {
+		echo "Error: File '" . $file . "' does not exist or is not readable\n";
 		exit( 1 );
 	}
 }
 
 // Show files
-if ( $command=="files" ) {
+if ( $command == "files" ) {
 	print_r( $files );
 	exit;
 }
 
 // Read cache file
 if ( file_exists( CACHEFILE ) ) {
-	verbose( "Using cache file ".CACHEFILE."\n" );
+	verbose( "Using cache file " . CACHEFILE . "\n" );
 	$cache = unserialize( file_get_contents( CACHEFILE ) );
 	$cache_orig = $cache;
 } else {
@@ -251,7 +251,7 @@ foreach ( $files as $file ) {
 }
 verbose( "\n" );
 
-$md5sum = md5( serialize( $functions ).serialize( $seetags ) );
+$md5sum = md5( serialize( $functions ) . serialize( $seetags ) );
 if ( isset( $cache['functions_seetags'] ) and $md5sum == $cache['functions_seetags'] ) {
 	// Use cache only if functions and seetags haven't changed
 	$use_cache = true;
@@ -260,7 +260,7 @@ if ( isset( $cache['functions_seetags'] ) and $md5sum == $cache['functions_seeta
 	$cache['functions_seetags'] = $md5sum;
 }
 
-if ( !extension_loaded( "tokenizer" ) ) {
+if ( ! extension_loaded( "tokenizer" ) ) {
 	echo "Error: The 'Tokenizer' extension for PHP is missing. See http://php.net/manual/en/book.tokenizer.php for more information.\n";
 	exit( 1 );
 }
@@ -269,7 +269,7 @@ verbose( "Process files\n" );
 $replaced = 0;
 foreach ( $files as $file ) {
 
-	verbose( " ".$file."\n" );
+	verbose( " " . $file . "\n" );
 	$source_orig = file_get_contents( $file );
 
 	// Cache
@@ -281,24 +281,25 @@ foreach ( $files as $file ) {
 	}
 
 	// Check encoding
-	if ( $encoding and !mb_check_encoding( $source_orig, $encoding ) ) {
-		echo "  File contains characters which are not valid in ".$encoding.":\n";
+	if ( $encoding and ! mb_check_encoding( $source_orig, $encoding ) ) {
+		echo "  File contains characters which are not valid in " . $encoding . ":\n";
 		$source_converted = mb_convert_encoding( $source_orig, $encoding );
 		$tmpfile = "/tmp/tmp.phptidy.php";
-		if ( !file_put_contents( $tmpfile, $source_converted ) ) {
-			echo "Error: The temporary file '".$tmpfile."' could not be saved.\n";
+		if ( ! file_put_contents( $tmpfile, $source_converted ) ) {
+			echo "Error: The temporary file '" . $tmpfile . "' could not be saved.\n";
 			exit( 1 );
 		}
-		system( "echo -ne '\\033[01;31m'; diff -u ".$file." ".$tmpfile." 2>&1; echo -ne '\\033[00m'" );
+		system( "echo -ne '\\033[01;31m'; diff -u " . $file . " " . $tmpfile . " 2>&1; echo -ne '\\033[00m'" );
 	}
 
 	// Process source code
 	$source = $source_orig;
 	$count = 0;
 	do {
+		++$count;
 		$source_in = $source;
 		$source = phptidy( $source_in );
-		++$count;
+
 		if ( $count > 3 ) {
 			echo "  Code processed 3 times and still not consistent!\n";
 			break;
@@ -315,25 +316,25 @@ foreach ( $files as $file ) {
 
 	// Output
 	switch ( $command ) {
-	case "suffix":
+		case "suffix":
 
-		$newfile = $file.".phptidy.php";
-		if ( !file_put_contents( $newfile, $source ) ) {
-			echo "Error: The file '".$newfile."' could not be saved.\n";
+		$newfile = $file . ".phptidy.php";
+		if ( ! file_put_contents( $newfile, $source ) ) {
+			echo "Error: The file '" . $newfile . "' could not be saved.\n";
 			exit( 1 );
 		}
-		verbose( "  ".$newfile." saved.\n" );
+		verbose( "  " . $newfile . " saved.\n" );
 
 		break;
-	case "replace":
+		case "replace":
 
-		$backupfile = dirname( $file ).( dirname( $file )?"/":"" ).".".basename( $file ).".phptidybak~";
-		if ( !copy( $file, $backupfile ) ) {
-			echo "Error: The file '".$backupfile."' could not be saved.\n";
+		$backupfile = dirname( $file ) . ( dirname( $file )?"/":"" ) . "." . basename( $file ) . ".phptidybak~";
+		if ( ! copy( $file, $backupfile ) ) {
+			echo "Error: The file '" . $backupfile . "' could not be saved.\n";
 			exit( 1 );
 		}
-		if ( !file_put_contents( $file, $source ) ) {
-			echo "Error: The file '".$file."' could not be overwritten.\n";
+		if ( ! file_put_contents( $file, $source ) ) {
+			echo "Error: The file '" . $file . "' could not be overwritten.\n";
 			exit( 1 );
 		}
 		verbose( "  replaced.\n" );
@@ -343,17 +344,17 @@ foreach ( $files as $file ) {
 		$cache['md5sums'][$file] = md5( $source );
 
 		break;
-	case "diff":
+		case "diff":
 
 		$tmpfile = "/tmp/tmp.phptidy.php";
-		if ( !file_put_contents( $tmpfile, $source ) ) {
-			echo "Error: The temporary file '".$tmpfile."' could not be saved.\n";
+		if ( ! file_put_contents( $tmpfile, $source ) ) {
+			echo "Error: The temporary file '" . $tmpfile . "' could not be saved.\n";
 			exit( 1 );
 		}
-		system( "echo -ne '\\033[01;34m'; diff -u ".$file." ".$tmpfile." 2>&1; echo -ne '\\033[00m'" );
+		system( "echo -ne '\\033[01;34m'; diff -u " . $file . " " . $tmpfile . " 2>&1; echo -ne '\\033[00m'" );
 
 		break;
-	case "source":
+		case "source":
 
 		echo $source;
 
@@ -362,14 +363,14 @@ foreach ( $files as $file ) {
 
 }
 
-if ( $command=="replace" ) {
+if ( $command == "replace" ) {
 	if ( $replaced ) {
-		verbose( "Replaced ".$replaced." files.\n" );
+		verbose( "Replaced " . $replaced . " files.\n" );
 	}
 	if ( $cache != $cache_orig ) {
-		verbose( "Write cache file ".CACHEFILE."\n" );
-		if ( !file_put_contents( CACHEFILE, serialize( $cache ) ) ) {
-			echo "Warning: The cache file '".CACHEFILE."' could not be saved.\n";
+		verbose( "Write cache file " . CACHEFILE . "\n" );
+		if ( ! file_put_contents( CACHEFILE, serialize( $cache ) ) ) {
+			echo "Warning: The cache file '" . CACHEFILE . "' could not be saved.\n";
 		}
 	}
 }
@@ -415,7 +416,7 @@ See README and source comments for more information.
 /**
  * Clean up source code
  *
- * @param string  $source
+ * @param string $source
  * @return string
  */
 function phptidy( $source ) {
@@ -428,8 +429,7 @@ function phptidy( $source ) {
 	$source = str_replace( "\r", "\n", $source );
 
 	$tokens = get_tokens( $source );
-
-	if ( $GLOBALS['command']=="tokens" ) {
+	if ( $GLOBALS['command'] == "tokens" ) {
 		print_tokens( $tokens );
 		exit;
 	}
@@ -475,13 +475,13 @@ function phptidy( $source ) {
 	// Strip trailing whitespace
 	$source = preg_replace( "/[ \t]+\n/", "\n", $source );
 
-	if ( substr( $source, -1 )!="\n" ) {
+	if ( substr( $source, - 1 ) != "\n" ) {
 		// Add one line break at the end of the file
 		// http://pear.php.net/manual/en/standards.file.php
 		$source .= "\n";
 	} else {
 		// Strip empty lines at the end of the file
-		while ( substr( $source, -2 )=="\n\n" ) $source = substr( $source, 0, -1 );
+		while ( substr( $source, - 2 ) == "\n\n" ) $source = substr( $source, 0, - 1 );
 	}
 
 	return $source;
@@ -491,10 +491,12 @@ function phptidy( $source ) {
 //////////////// TOKEN FUNCTIONS ///////////////////
 
 
+
+
 /**
  * Returns the text part of a token
  *
- * @param mixed   $token
+ * @param mixed $token
  * @return string
  */
 function token_text( $token ) {
@@ -506,15 +508,15 @@ function token_text( $token ) {
 /**
  * Prints all tokens
  *
- * @param array   $tokens
+ * @param array $tokens
  */
 function print_tokens( $tokens ) {
 	foreach ( $tokens as $token ) {
 		if ( is_string( $token ) ) {
-			echo $token."\n";
+			echo $token . "\n";
 		} else {
 			list( $id, $text ) = $token;
-			echo token_name( $id )." ".addcslashes( $text, "\0..\40!@\@\177..\377" )."\n";
+			echo token_name( $id ) . " " . addcslashes( $text, "\0..\40!@\@\177..\377" ) . "\n";
 		}
 	}
 }
@@ -523,7 +525,7 @@ function print_tokens( $tokens ) {
 /**
  * Wrapper for token_get_all(), because there is new mysterious index 2 ...
  *
- * @param string  $source
+ * @param string $source
  * @return array
  */
 function get_tokens( &$source ) {
@@ -538,7 +540,7 @@ function get_tokens( &$source ) {
 /**
  * Combines the tokens to the source code
  *
- * @param array   $tokens
+ * @param array $tokens
  * @return string
  */
 function combine_tokens( $tokens ) {
@@ -561,18 +563,18 @@ function combine_tokens( $tokens ) {
  * @param integer $key
  * @param string  $message (optional)
  */
-function possible_syntax_error( $tokens, $key, $message="" ) {
+function possible_syntax_error( $tokens, $key, $message = "" ) {
 	echo "Possible syntax error detected";
-	if ( $message ) echo " (".$message.")";
+	if ( $message ) echo " (" . $message . ")";
 	echo ":\n";
-	echo combine_tokens( array_slice( $tokens, max( 0, $key-5 ), 10 ) )."\n";
+	echo combine_tokens( array_slice( $tokens, max( 0, $key - 5 ), 10 ) ) . "\n";
 }
 
 
 /**
  * Removes whitespace from the beginning of a token array
  *
- * @param array   $tokens
+ * @param array $tokens
  */
 function tokens_ltrim( &$tokens ) {
 	while (
@@ -587,14 +589,14 @@ function tokens_ltrim( &$tokens ) {
 /**
  * Removes whitespace from the end of a token array
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function tokens_rtrim( &$tokens ) {
 	while (
-		isset( $tokens[$k=count( $tokens )-1][0] ) and
-		$tokens[$k][0] === T_WHITESPACE
+		isset( $tokens[ $k = count( $tokens ) - 1 ][0] ) and
+		$tokens[ $k ][0] === T_WHITESPACE
 	) {
-		array_splice( $tokens, -1 );
+		array_splice( $tokens, - 1 );
 	}
 }
 
@@ -602,7 +604,7 @@ function tokens_rtrim( &$tokens ) {
 /**
  * Removes all whitespace
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function strip_whitespace( &$tokens ) {
 	foreach ( $tokens as $key => $token ) {
@@ -610,7 +612,7 @@ function strip_whitespace( &$tokens ) {
 			isset( $token[0] ) and
 			$token[0] === T_WHITESPACE
 		) {
-			unset( $tokens[$key] );
+			unset( $tokens[ $key ] );
 		}
 	}
 	$tokens = array_values( $tokens );
@@ -632,8 +634,8 @@ function get_argument_tokens( &$tokens, $key ) {
 	$curly_braces_count = 0;
 
 	++$key;
-	while ( isset( $tokens[$key] ) ) {
-		$token = &$tokens[$key];
+	while ( isset( $tokens[ $key ] ) ) {
+		$token = &$tokens[ $key ];
 
 		if ( is_string( $token ) ) {
 			if ( $token === ";" ) break;
@@ -675,7 +677,7 @@ function get_argument_tokens( &$tokens, $key ) {
 /**
  * Checks for some tokens which must not be touched
  *
- * @param array   $token
+ * @param array $token
  * @return boolean
  */
 function token_is_taboo( &$token ) {
@@ -695,7 +697,7 @@ function token_is_taboo( &$token ) {
 /**
  * Converts commands to lower case
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function fix_token_case( &$tokens ) {
 
@@ -780,7 +782,7 @@ function fix_token_case( &$tokens ) {
 /**
  * Converts builtin functions to lower case
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function fix_builtin_functions_case( &$tokens ) {
 
@@ -795,13 +797,13 @@ function fix_builtin_functions_case( &$tokens ) {
 		if (
 			is_string( $token ) or
 			$token[0] !== T_STRING or
-			!isset( $tokens[$key+2] ) or
+			! isset( $tokens[ $key + 2 ] ) or
 			// Ignore object methods
-			( is_array( $tokens[$key-1] ) and $tokens[$key-1][0] === T_OBJECT_OPERATOR )
+			( is_array( $tokens[ $key - 1 ] ) and $tokens[ $key - 1 ][0] === T_OBJECT_OPERATOR )
 		) continue;
 
 		if (
-			$tokens[$key+1] === "("
+			$tokens[ $key + 1 ] === "("
 		) {
 			$lowercase = strtolower( $token[1] );
 			if (
@@ -811,15 +813,15 @@ function fix_builtin_functions_case( &$tokens ) {
 				$token[1] = $lowercase;
 			}
 		} elseif (
-			$tokens[$key+2] === "(" and
-			is_array( $tokens[$key+1] ) and $tokens[$key+1][0] === T_WHITESPACE
+			$tokens[ $key + 2 ] === "(" and
+			is_array( $tokens[ $key + 1 ] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE
 		) {
 			if (
 				in_array( strtolower( $token[1] ), $defined_internal_functions )
 			) {
 				$token[1] = strtolower( $token[1] );
 				// Remove whitespace between function name and opening round bracket
-				unset( $tokens[$key+1] );
+				unset( $tokens[ $key + 1 ] );
 			}
 		}
 
@@ -832,17 +834,17 @@ function fix_builtin_functions_case( &$tokens ) {
 /**
  * Replaces inline tabs with spaces
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function replace_inline_tabs( &$tokens ) {
 
 	foreach ( $tokens as &$token ) {
 
 		if ( is_string( $token ) ) {
-			$text =& $token;
+			$text = & $token;
 		} else {
 			if ( token_is_taboo( $token ) ) continue;
-			$text =& $token[1];
+			$text = & $token[1];
 		}
 
 		// Replace one tab with one space
@@ -856,7 +858,7 @@ function replace_inline_tabs( &$tokens ) {
 /**
  * Replaces PHP-Open-Tags with consistent tags
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function replace_phptags( &$tokens ) {
 
@@ -864,7 +866,7 @@ function replace_phptags( &$tokens ) {
 		if ( is_string( $token ) ) continue;
 
 		switch ( $token[0] ) {
-		case T_OPEN_TAG:
+			case T_OPEN_TAG:
 
 			// The open tag is already the right one
 			if ( rtrim( $token[1] ) == $GLOBALS['open_tag'] ) continue;
@@ -872,12 +874,12 @@ function replace_phptags( &$tokens ) {
 			// Collect following whitespace
 			preg_match( "/\s*$/", $token[1], $matches );
 			$whitespace = $matches[0];
-			if ( $tokens[$key+1][0] === T_WHITESPACE ) {
-				$whitespace .= $tokens[$key+1][1];
-				array_splice( $tokens, $key+1, 1 );
+			if ( $tokens[ $key + 1 ][0] === T_WHITESPACE ) {
+				$whitespace .= $tokens[ $key + 1 ][1];
+				array_splice( $tokens, $key + 1, 1 );
 			}
 
-			if ( $GLOBALS['open_tag']=="<?" ) {
+			if ( $GLOBALS['open_tag'] == "<?" ) {
 
 				// Short open tags have the following whitespace in a seperate token
 				array_splice( $tokens, $key, 1, array(
@@ -889,17 +891,17 @@ function replace_phptags( &$tokens ) {
 
 				// Long open tags have the following whitespace included in the token string
 				switch ( strlen( $whitespace ) ) {
-				case 0:
+					case 0:
 					// Add an additional space if no whitespace is found
 					$whitespace = " ";
-				case 1:
+					case 1:
 					// Use the one found space or newline
-					$tokens[$key][1] = $GLOBALS['open_tag'].$whitespace;
+					$tokens[ $key ][1] = $GLOBALS['open_tag'] . $whitespace;
 					break;
-				default:
+					default:
 					// Use the first space or newline for the open tag and append the rest of the whitespace as a seperate token
 					array_splice( $tokens, $key, 1, array(
-							array( T_OPEN_TAG, $GLOBALS['open_tag'].substr( $whitespace, 0, 1 ) ),
+							array( T_OPEN_TAG, $GLOBALS['open_tag'] . substr( $whitespace, 0, 1 ) ),
 							array( T_WHITESPACE, substr( $whitespace, 1 ) )
 						) );
 				}
@@ -907,21 +909,21 @@ function replace_phptags( &$tokens ) {
 			}
 
 			break;
-		case T_OPEN_TAG_WITH_ECHO:
+			case T_OPEN_TAG_WITH_ECHO:
 
 			// If we use short tags we also accept the echo tags
-			if ( $GLOBALS['open_tag']=="<?" ) continue;
+			if ( $GLOBALS['open_tag'] == "<?" ) continue;
 
-			if ( $tokens[$key+1][0] === T_WHITESPACE ) {
+			if ( $tokens[ $key + 1 ][0] === T_WHITESPACE ) {
 				// If there is already whitespace following we only replace the open tag
 				array_splice( $tokens, $key, 1, array(
-						array( T_OPEN_TAG, $GLOBALS['open_tag']." " ),
+						array( T_OPEN_TAG, $GLOBALS['open_tag'] . " " ),
 						array( T_ECHO, "echo" )
 					) );
 			} else {
 				// If there is no whitespace following we add one space
 				array_splice( $tokens, $key, 1, array(
-						array( T_OPEN_TAG, $GLOBALS['open_tag']." " ),
+						array( T_OPEN_TAG, $GLOBALS['open_tag'] . " " ),
 						array( T_ECHO, "echo" ),
 						array( T_WHITESPACE, " " )
 					) );
@@ -939,7 +941,7 @@ function replace_phptags( &$tokens ) {
  *
  * http://pear.php.net/manual/en/standards.comments.php
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function replace_shell_comments( &$tokens ) {
 
@@ -949,7 +951,7 @@ function replace_shell_comments( &$tokens ) {
 			$token[0] === T_COMMENT and
 			substr( $token[1], 0, 1 ) === "#"
 		) {
-			$token[1] = "//".substr( $token[1], 1 );
+			$token[1] = "//" . substr( $token[1], 1 );
 		}
 	}
 
@@ -961,7 +963,7 @@ function replace_shell_comments( &$tokens ) {
  *
  * http://pear.php.net/manual/en/standards.including.php
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function fix_statement_brackets( &$tokens ) {
 
@@ -978,14 +980,14 @@ function fix_statement_brackets( &$tokens ) {
 
 	foreach ( $tokens as $key => &$token ) {
 
-		if ( is_string( $token ) or !in_array( $token[0], $statement_tokens ) ) continue;
+		if ( is_string( $token ) or ! in_array( $token[0], $statement_tokens ) ) continue;
 
 		$tokens_arg = get_argument_tokens( $tokens, $key );
 		$tokens_arg_orig = $tokens_arg;
 
 		tokens_ltrim( $tokens_arg );
 
-		if ( !count( $tokens_arg ) or $tokens_arg[0] !== "(" ) continue;
+		if ( ! count( $tokens_arg ) or $tokens_arg[0] !== "(" ) continue;
 
 		tokens_rtrim( $tokens_arg );
 
@@ -997,7 +999,7 @@ function fix_statement_brackets( &$tokens ) {
 				elseif ( $t === ")" ) --$round_braces_count;
 				else continue;
 				// Check if the expression begins without a bracket or if the bracket was closed before the end of the expression was reached
-				if ( $round_braces_count == 0 and $k != count( $tokens_arg )-1 ) {
+				if ( $round_braces_count == 0 and $k != count( $tokens_arg ) - 1 ) {
 					continue 2;
 				}
 				if ( $round_braces_count < 0 ) {
@@ -1006,7 +1008,7 @@ function fix_statement_brackets( &$tokens ) {
 				}
 			} else {
 				// Do not touch multiline expressions
-				if ( $t[0] === T_WHITESPACE and strpos( $t[1], "\n" )!==false ) {
+				if ( $t[0] === T_WHITESPACE and strpos( $t[1], "\n" ) !== false ) {
 					continue 2;
 				}
 			}
@@ -1018,7 +1020,7 @@ function fix_statement_brackets( &$tokens ) {
 		}
 
 		// Remove the outermost brackets
-		$tokens_arg = array_slice( $tokens_arg, 1, -1 );
+		$tokens_arg = array_slice( $tokens_arg, 1, - 1 );
 
 		tokens_ltrim( $tokens_arg );
 		tokens_rtrim( $tokens_arg );
@@ -1028,7 +1030,7 @@ function fix_statement_brackets( &$tokens ) {
 			array_unshift( $tokens_arg, array( T_WHITESPACE, " " ) );
 		}
 
-		array_splice( $tokens, $key+1, count( $tokens_arg_orig ), $tokens_arg );
+		array_splice( $tokens, $key + 1, count( $tokens_arg_orig ), $tokens_arg );
 
 	}
 
@@ -1038,7 +1040,7 @@ function fix_statement_brackets( &$tokens ) {
 /**
  * Fixes whitespace between commands and braces
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function fix_separation_whitespace( &$tokens ) {
 
@@ -1048,95 +1050,95 @@ function fix_separation_whitespace( &$tokens ) {
 		if ( is_string( $token ) ) {
 
 			// Exactly 1 space or a newline between closing round bracket and opening curly bracket
-			if ( $tokens[$key] === ")" ) {
+			if ( $tokens[ $key ] === ")" ) {
 				if (
-					isset( $tokens[$key+1] ) and $tokens[$key+1] === "{"
+					isset( $tokens[ $key + 1 ] ) and $tokens[ $key + 1 ] === "{"
 				) {
 					// Insert an additional space or newline before the bracket
-					array_splice( $tokens, $key+1, 0, array(
+					array_splice( $tokens, $key + 1, 0, array(
 							array( T_WHITESPACE, separation_whitespace( $control_structure ) )
 						) );
 				} elseif (
-					isset( $tokens[$key+1][0] ) and $tokens[$key+1][0] === T_WHITESPACE and
-					isset( $tokens[$key+2] ) and $tokens[$key+2] === "{"
+					isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
+					isset( $tokens[ $key + 2 ] ) and $tokens[ $key + 2 ] === "{"
 				) {
 					// Set the existing whitespace before the bracket to exactly one space or newline
-					$tokens[$key+1][1] = separation_whitespace( $control_structure );
+					$tokens[ $key + 1 ][1] = separation_whitespace( $control_structure );
 				}
 			}
 
 		} else {
 
 			switch ( $token[0] ) {
-			case T_CLASS:
+				case T_CLASS:
 				// Class definition
 				if (
-					isset( $tokens[$key+1][0] ) and $tokens[$key+1][0] === T_WHITESPACE and
-					isset( $tokens[$key+2][0] ) and $tokens[$key+2][0] === T_STRING
+					isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
+					isset( $tokens[ $key + 2 ][0] ) and $tokens[ $key + 2 ][0] === T_STRING
 				) {
 					// Exactly 1 space between 'class' and the class name
-					$tokens[$key+1][1] = " ";
+					$tokens[ $key + 1 ][1] = " ";
 					// Exactly 1 space between the class name and the opening curly bracket
-					if ( $tokens[$key+3] === "{" ) {
+					if ( $tokens[ $key + 3 ] === "{" ) {
 						// Insert an additional space or newline before the bracket
-						array_splice( $tokens, $key+3, 0, array(
+						array_splice( $tokens, $key + 3, 0, array(
 								array( T_WHITESPACE, separation_whitespace( T_CLASS ) )
 							) );
 					} elseif (
-						isset( $tokens[$key+3][0] ) and $tokens[$key+3][0] === T_WHITESPACE and
-						isset( $tokens[$key+4] ) and $tokens[$key+4] === "{"
+						isset( $tokens[ $key + 3 ][0] ) and $tokens[ $key + 3 ][0] === T_WHITESPACE and
+						isset( $tokens[ $key + 4 ] ) and $tokens[ $key + 4 ] === "{"
 					) {
 						// Set the existing whitespace before the bracket to exactly one space or a newline
-						$tokens[$key+3][1] = separation_whitespace( T_CLASS );
+						$tokens[ $key + 3 ][1] = separation_whitespace( T_CLASS );
 					}
 				}
 				break;
-			case T_FUNCTION:
+				case T_FUNCTION:
 				// Function definition
 				if (
-					isset( $tokens[$key+1][0] ) and $tokens[$key+1][0] === T_WHITESPACE and
-					isset( $tokens[$key+2][0] ) and $tokens[$key+2][0] === T_STRING
+					isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
+					isset( $tokens[ $key + 2 ][0] ) and $tokens[ $key + 2 ][0] === T_STRING
 				) {
 					// Exactly 1 Space between 'function' and the function name
-					$tokens[$key+1][1] = " ";
+					$tokens[ $key + 1 ][1] = " ";
 					// No whitespace between function name and opening round bracket
-					if ( isset( $tokens[$key+3][0] ) and $tokens[$key+3][0] === T_WHITESPACE ) {
+					if ( isset( $tokens[ $key + 3 ][0] ) and $tokens[ $key + 3 ][0] === T_WHITESPACE ) {
 						// Remove the whitespace
-						array_splice( $tokens, $key+3, 1 );
+						array_splice( $tokens, $key + 3, 1 );
 					}
 				}
 				break;
-			case T_IF:
-			case T_ELSEIF:
-			case T_FOR:
-			case T_FOREACH:
-			case T_WHILE:
-			case T_SWITCH:
+				case T_IF:
+				case T_ELSEIF:
+				case T_FOR:
+				case T_FOREACH:
+				case T_WHILE:
+				case T_SWITCH:
 				// At least 1 space between a statement and a opening round bracket
-				if ( $tokens[$key+1] === "(" ) {
+				if ( $tokens[ $key + 1 ] === "(" ) {
 					// Insert an additional space or newline before the bracket
-					array_splice( $tokens, $key+1, 0, array(
+					array_splice( $tokens, $key + 1, 0, array(
 							array( T_WHITESPACE, separation_whitespace( T_SWITCH ) ),
 						) );
 				}
 				break;
-			case T_ELSE:
-			case T_DO:
+				case T_ELSE:
+				case T_DO:
 				// Exactly 1 space between a command and a opening curly bracket
-				if ( $tokens[$key+1] === "{" ) {
+				if ( $tokens[ $key + 1 ] === "{" ) {
 					// Insert an additional space or newline before the bracket
-					array_splice( $tokens, $key+1, 0, array(
+					array_splice( $tokens, $key + 1, 0, array(
 							array( T_WHITESPACE, separation_whitespace( T_DO ) ),
 						) );
 				} elseif (
-					isset( $tokens[$key+1][0] ) and $tokens[$key+1][0] === T_WHITESPACE and
-					isset( $tokens[$key+2] ) and $tokens[$key+2] === "{"
+					isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE and
+					isset( $tokens[ $key + 2 ] ) and $tokens[ $key + 2 ] === "{"
 				) {
 					// Set the existing whitespace before the bracket to exactly one space or a newline
-					$tokens[$key+1][1] = separation_whitespace( T_DO );
+					$tokens[ $key + 1 ][1] = separation_whitespace( T_DO );
 				}
 				break;
-			default:
+				default:
 				// Do not set $control_structure if the token is no control structure
 				continue 2;
 			}
@@ -1158,7 +1160,7 @@ function fix_separation_whitespace( &$tokens ) {
  */
 function separation_whitespace( $control_structure ) {
 	if (
-		$GLOBALS['curly_brace_newline']===true or (
+		$GLOBALS['curly_brace_newline'] === true or (
 			is_array( $GLOBALS['curly_brace_newline'] ) and
 			in_array( $control_structure, $GLOBALS['curly_brace_newline'] )
 		)
@@ -1170,20 +1172,20 @@ function separation_whitespace( $control_structure ) {
 /**
  * Adds one space after a comma
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function fix_comma_space( &$tokens ) {
 
 	foreach ( $tokens as $key => &$token ) {
-		if ( !is_string( $token ) ) continue;
+		if ( ! is_string( $token ) ) continue;
 		if (
 			// If the current token ends with a comma...
-			substr( $token, -1 ) === "," and
+			substr( $token, - 1 ) === "," and
 			// ...and the next token is no whitespace
-			!( isset( $tokens[$key+1][0] ) and $tokens[$key+1][0] === T_WHITESPACE )
+			! ( isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE )
 		) {
 			// Insert one space
-			array_splice( $tokens, $key+1, 0, array(
+			array_splice( $tokens, $key + 1, 0, array(
 					array( T_WHITESPACE, " " )
 				) );
 		}
@@ -1194,37 +1196,41 @@ function fix_comma_space( &$tokens ) {
 /**
  * Adds one space after a round bracket
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function fix_round_bracket_space( &$tokens ) {
 
 	foreach ( $tokens as $key => &$token ) {
-		if ( !is_string( $token ) ) continue;
+		if ( ! is_string( $token ) ) continue;
 		if (
 			// If the current token is a start round bracket...
 			$token === "(" and
 			// ...and the next token is no whitespace
-			!( isset( $tokens[$key+1][0] ) and $tokens[$key+1][0] === T_WHITESPACE ) and
+			! ( isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE ) and
 			// ...and the next token is not an end round bracket
-			!( isset( $tokens[$key+1][0] ) and $tokens[$key+1][0] === ')' )
+			! ( isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === ')' )
 		) {
 			// Insert one space
-			array_splice( $tokens, $key+1, 0, array(
+			array_splice( $tokens, $key + 1, 0, array(
 					array( T_WHITESPACE, " " )
 				) );
 		}
 		else if (
-			// If the current token is an end round bracket...
-			$token === ")" and
-			// ...and the previous token is no whitespace
-			!( isset( $tokens[$key-1][0] ) and $tokens[$key-1][0] === T_WHITESPACE ) and
-			// ...and the previous token is a start round bracket
-			!( isset( $tokens[$key-1][0] ) and $tokens[$key-1][0] === '(' )
-		) {
-			// Insert one space
-			array_splice( $tokens, $key, 0, array(
-					array( T_WHITESPACE, " " )
-				) );
+				// If the current token is an end round bracket...
+				$token === ")" and
+				// ...and the previous token is no whitespace
+				! ( isset( $tokens[ $key - 1 ][0] ) and $tokens[ $key - 1 ][0] === T_WHITESPACE ) and
+				// ...and the previous token is a start round bracket
+				! ( isset( $tokens[ $key - 1 ][0] ) and $tokens[ $key - 1 ][0] === '(' )
+			) {
+				// Insert one space
+				array_splice( $tokens, $key, 0, array(
+						array( T_WHITESPACE, " " )
+					) );
+			}
+	}
+}
+
 /**
  * Add one space before and after some operators.
  *
@@ -1460,9 +1466,11 @@ function fix_square_bracket_space( &$tokens ) {
 
 	$tokens = array_values( $tokens );
 }
+
+/**
  * Fixes the format of a DocBlock
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function fix_docblock_format( &$tokens ) {
 
@@ -1470,7 +1478,7 @@ function fix_docblock_format( &$tokens ) {
 
 		if ( is_string( $token ) or $token[0] !== T_DOC_COMMENT ) continue;
 
-		$lines_orig = explode( "\n", $tokens[$key][1] );
+		$lines_orig = explode( "\n", $tokens[ $key ][1] );
 
 		$lines = array();
 		$comments_started = false;
@@ -1481,38 +1489,39 @@ function fix_docblock_format( &$tokens ) {
 		foreach ( $lines_orig as $line ) {
 			$line = trim( $line );
 			// Strip empty lines
-			if ( $line=="" ) continue;
-			if ( $line!="/**" and $line!="*/" ) {
+			if ( $line == "" ) continue;
+			if ( $line != "/**" and $line != "*/" ) {
 
 				// test for single-line comments
 				$docblock_start = '/**';
 				$docblock_end = '*/';
 				if ( substr( $line, 0, 3 ) === $docblock_start and
-					substr_compare($line, $docblock_end, -strlen($docblock_end), strlen($docblock_end)) === 0
-					) {
-					return;
+					substr_compare( $line, $docblock_end, -strlen( $docblock_end ), strlen( $docblock_end ) ) === 0
+				) {
+					$lines[] = $line;
+					break;
 				} else {
 					// Add stars where missing
-					if ( substr( $line, 0, 1 )!="*" ) {
-					 $line = "* ".$line;
+					if ( substr( $line, 0, 1 ) != "*" ) {
+						$line = "* " . $line;
 					}
-					elseif( $line!="*" and substr( $line, 0, 2 )!="* " ) {
-					 $line = "* ".substr( $line, 1 );
+					elseif ( $line != "*" and substr( $line, 0, 2 ) != "* " ) {
+						$line = "* " . substr( $line, 1 );
 					}
 				}
 
 				// Strip empty lines at the beginning
-				if ( !$comments_started ) {
-					if ( $line=="*" and count( $lines_orig )>3 ) continue;
+				if ( ! $comments_started ) {
+					if ( $line == "*" and count( $lines_orig ) > 3 ) continue;
 					$comments_started = true;
 				}
 
-				if ( substr( $line, 0, 3 )=="* @" ) {
+				if ( substr( $line, 0, 3 ) == "* @" ) {
 
 					// Add empty line before DocTags if missing
-					if ( !$doctags_started ) {
-						if ( $last_line!="*" ) $lines[] = "*";
-						if ( $last_line=="/**" ) $lines[] = "*";
+					if ( ! $doctags_started ) {
+						if ( $last_line != "*" ) $lines[] = "*";
+						if ( $last_line == "/**" ) $lines[] = "*";
 						$doctags_started = true;
 					}
 
@@ -1548,7 +1557,7 @@ function fix_docblock_format( &$tokens ) {
 					$line .= str_pad( $matches[4], $param_max_variable_length ) . " ";
 				}
 				$line .= trim( $matches[5] );
-				$lines[$l] = $line;
+				$lines[ $l ] = $line;
 			}
 
 		}
@@ -1563,7 +1572,7 @@ function fix_docblock_format( &$tokens ) {
 /**
  * Adjusts empty lines after DocBlocks
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function fix_docblock_space( &$tokens ) {
 
@@ -1576,26 +1585,26 @@ function fix_docblock_space( &$tokens ) {
 		if ( $filedocblock ) {
 
 			// Exactly 2 empty lines after the file DocBlock
-			if ( $tokens[$key+1][0] === T_WHITESPACE ) {
-				$tokens[$key+1][1] = preg_replace( "/\n([ \t]*\n)*/", "\n\n\n", $tokens[$key+1][1] );
+			if ( $tokens[ $key + 1 ][0] === T_WHITESPACE ) {
+				$tokens[ $key + 1 ][1] = preg_replace( "/\n([ \t]*\n)*/", "\n\n\n", $tokens[ $key + 1 ][1] );
 			}
 			$filedocblock = false;
 
 		} else {
 
 			// Delete empty lines after the DocBlock
-			if ( $tokens[$key+1][0] === T_WHITESPACE ) {
-				$tokens[$key+1][1] = preg_replace( "/\n([ \t]*\n)+/", "\n", $tokens[$key+1][1] );
+			if ( $tokens[ $key + 1 ][0] === T_WHITESPACE ) {
+				$tokens[ $key + 1 ][1] = preg_replace( "/\n([ \t]*\n)+/", "\n", $tokens[ $key + 1 ][1] );
 			}
 
 			// Add empty lines before the DocBlock
-			if ( $tokens[$key-1][0] === T_WHITESPACE ) {
+			if ( $tokens[ $key - 1 ][0] === T_WHITESPACE ) {
 				$n = 2;
-				if ( substr( token_text( $tokens[$key-2] ), -1 ) == "\n" ) --$n;
+				if ( substr( token_text( $tokens[ $key - 2 ] ), - 1 ) == "\n" ) --$n;
 				// At least 2 empty lines before the docblock of a function
-				if ( $tokens[$key+2][0] === T_FUNCTION ) ++$n;
-				if ( strpos( $tokens[$key-1][1], str_repeat( "\n", $n ) ) === false ) {
-					$tokens[$key-1][1] = preg_replace( "/(\n){1,".$n."}/", str_repeat( "\n", $n ), $tokens[$key-1][1] );
+				if ( $tokens[ $key + 2 ][0] === T_FUNCTION ) ++$n;
+				if ( strpos( $tokens[ $key - 1 ][1], str_repeat( "\n", $n ) ) === false ) {
+					$tokens[ $key - 1 ][1] = preg_replace( "/(\n){1," . $n . "}/", str_repeat( "\n", $n ), $tokens[ $key - 1 ][1] );
 				}
 			}
 
@@ -1609,7 +1618,7 @@ function fix_docblock_space( &$tokens ) {
 /**
  * Adds 2 blank lines after functions and classes
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function add_blank_lines( &$tokens ) {
 
@@ -1650,16 +1659,16 @@ function add_blank_lines( &$tokens ) {
 		if ( $token === "}" ) {
 
 			if (
-				$curly_brace_opener[$curly_braces_count] === T_FUNCTION or
-				$curly_brace_opener[$curly_braces_count] === T_CLASS
+				$curly_brace_opener[ $curly_braces_count ] === T_FUNCTION or
+				$curly_brace_opener[ $curly_braces_count ] === T_CLASS
 			) {
 
 				// At least 2 blank lines after a function or class
 				if (
-					$tokens[$key+1][0] === T_WHITESPACE and
-					substr( $tokens[$key+1][1], 0, 2 ) != "\n\n\n"
+					$tokens[ $key + 1 ][0] === T_WHITESPACE and
+					substr( $tokens[ $key + 1 ][1], 0, 2 ) != "\n\n\n"
 				) {
-					$tokens[$key+1][1] = preg_replace( "/^([ \t]*\n){1,3}/", "\n\n\n", $tokens[$key+1][1] );
+					$tokens[ $key + 1 ][1] = preg_replace( "/^([ \t]*\n){1,3}/", "\n\n\n", $tokens[ $key + 1 ][1] );
 				}
 
 			}
@@ -1676,7 +1685,7 @@ function add_blank_lines( &$tokens ) {
 		) {
 
 			++$curly_braces_count;
-			$curly_brace_opener[$curly_braces_count] = $control_structure;
+			$curly_brace_opener[ $curly_braces_count ] = $control_structure;
 
 		}
 
@@ -1688,7 +1697,7 @@ function add_blank_lines( &$tokens ) {
 /**
  * Indenting
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function indent( &$tokens ) {
 
@@ -1723,25 +1732,25 @@ function indent( &$tokens ) {
 		}
 
 		// The closing bracket itself has to be not indented again, so we decrease the brackets count before we reach the bracket.
-		if ( isset( $tokens[$key+1] ) ) {
-			if ( is_string( $tokens[$key+1] ) ) {
+		if ( isset( $tokens[ $key + 1 ] ) ) {
+			if ( is_string( $tokens[ $key + 1 ] ) ) {
 				if (
 					is_string( $token ) or
 					$token[0] !== T_WHITESPACE or
-					strpos( $token[1], "\n" )!==false
+					strpos( $token[1], "\n" ) !== false
 				) {
-					if     ( $tokens[$key+1] === "}" ) --$curly_braces_count;
-					elseif ( $tokens[$key+1] === ")" ) --$round_braces_count;
+					if     ( $tokens[ $key + 1 ] === "}" ) --$curly_braces_count;
+					elseif ( $tokens[ $key + 1 ] === ")" ) --$round_braces_count;
 				}
 			} else {
 				if (
 					// If the next token is a T_WHITESPACE without a \n, we have to look at the one after the next.
-					isset( $tokens[$key+2] ) and
-					$tokens[$key+1][0] === T_WHITESPACE and
-					strpos( $tokens[$key+1][1], "\n" )===false
+					isset( $tokens[ $key + 2 ] ) and
+					$tokens[ $key + 1 ][0] === T_WHITESPACE and
+					strpos( $tokens[ $key + 1 ][1], "\n" ) === false
 				) {
-					if     ( $tokens[$key+2] === "}" ) --$curly_braces_count;
-					elseif ( $tokens[$key+2] === ")" ) --$round_braces_count;
+					if     ( $tokens[ $key + 2 ] === "}" ) --$curly_braces_count;
+					elseif ( $tokens[ $key + 2 ] === ")" ) --$round_braces_count;
 				}
 			}
 		}
@@ -1751,19 +1760,19 @@ function indent( &$tokens ) {
 
 		if ( $token === "(" ) {
 
-			if ( $round_braces_control==1 ) {
+			if ( $round_braces_control == 1 ) {
 				// Remember which command was before the bracket
 				$k = $key;
 				do {
 					--$k;
 				} while (
-					isset( $tokens[$k] ) and (
-						$tokens[$k][0] === T_WHITESPACE or
-						$tokens[$k][0] === T_STRING
+					isset( $tokens[ $k ] ) and (
+						$tokens[ $k ][0] === T_WHITESPACE or
+						$tokens[ $k ][0] === T_STRING
 					)
 				);
-				if ( is_array( $tokens[$k] ) ) {
-					$round_brace_opener = $tokens[$k][0];
+				if ( is_array( $tokens[ $k ] ) ) {
+					$round_brace_opener = $tokens[ $k ][0];
 				} else {
 					$round_brace_opener = false;
 				}
@@ -1786,15 +1795,15 @@ function indent( &$tokens ) {
 			)
 		) {
 			// All control stuctures end with a curly bracket, except "else" and "do".
-			if ( isset( $control_structure[$curly_braces_count] ) ) {
-				++$control_structure[$curly_braces_count];
+			if ( isset( $control_structure[ $curly_braces_count ] ) ) {
+				++$control_structure[ $curly_braces_count ];
 			} else {
-				$control_structure[$curly_braces_count] = 1;
+				$control_structure[ $curly_braces_count ] = 1;
 			}
 
 		} elseif ( $token === ";" or $token === "}" ) {
 			// After a command or a set of commands a control structure is closed.
-			if ( !empty( $control_structure[$curly_braces_count] ) ) --$control_structure[$curly_braces_count];
+			if ( ! empty( $control_structure[ $curly_braces_count ] ) ) --$control_structure[ $curly_braces_count ];
 
 		} else {
 			indent_text(
@@ -1818,10 +1827,10 @@ function indent( &$tokens ) {
 			)
 		) {
 			// If a curly bracket occurs, no command without brackets can follow.
-			if ( !empty( $control_structure[$curly_braces_count] ) ) --$control_structure[$curly_braces_count];
+			if ( ! empty( $control_structure[ $curly_braces_count ] ) ) --$control_structure[ $curly_braces_count ];
 			++$curly_braces_count;
 			// Inside of the new level of curly brackets it starts with no control structure.
-			$control_structure[$curly_braces_count] = 0;
+			$control_structure[ $curly_braces_count ] = 0;
 		}
 
 	}
@@ -1842,20 +1851,20 @@ function indent( &$tokens ) {
  */
 function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, $control_structure, $docblock, &$trinity_started ) {
 
-	if ( is_string( $tokens[$key] ) ) {
-		$text =& $tokens[$key];
+	if ( is_string( $tokens[ $key ] ) ) {
+		$text = & $tokens[ $key ];
 		// If there is no line break it is only a inline string, not involved in indenting
-		if ( strpos( $text, "\n" )===false ) return;
+		if ( strpos( $text, "\n" ) === false ) return;
 	} else {
-		$text =& $tokens[$key][1];
+		$text = & $tokens[ $key ][1];
 		// If there is no line break it is only a inline string, not involved in indenting
-		if ( strpos( $text, "\n" )===false ) return;
-		if ( token_is_taboo( $tokens[$key] ) ) return;
+		if ( strpos( $text, "\n" ) === false ) return;
+		if ( token_is_taboo( $tokens[ $key ] ) ) return;
 	}
 
 	$indent = $curly_braces_count + $round_braces_count;
-	for ( $i=0; $i<=$curly_braces_count; ++$i ) {
-		$indent += $control_structure[$i];
+	for ( $i = 0; $i <= $curly_braces_count; ++$i ) {
+		$indent += $control_structure[ $i ];
 	}
 
 	// One indentation level less for "switch ... case ... default"
@@ -1878,25 +1887,25 @@ function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, 
 
 	// One indentation level less for an opening curly brace on a seperate line
 	if (
-		isset( $tokens[$key+2] ) and (
-			$tokens[$key+1] === "{" or (
-				is_array( $tokens[$key+1] ) and (
-					$tokens[$key+1][0] === T_CURLY_OPEN or
-					$tokens[$key+1][0] === T_DOLLAR_OPEN_CURLY_BRACES
+		isset( $tokens[ $key + 2 ] ) and (
+			$tokens[ $key + 1 ] === "{" or (
+				is_array( $tokens[ $key + 1 ] ) and (
+					$tokens[ $key + 1 ][0] === T_CURLY_OPEN or
+					$tokens[ $key + 1 ][0] === T_DOLLAR_OPEN_CURLY_BRACES
 				)
 			)
 		) and (
-			is_array( $tokens[$key+2] ) and
-			$tokens[$key+2][0] === T_WHITESPACE and
-			strpos( $tokens[$key+2][1], "\n" )!==false
+			is_array( $tokens[ $key + 2 ] ) and
+			$tokens[ $key + 2 ][0] === T_WHITESPACE and
+			strpos( $tokens[ $key + 2 ][1], "\n" ) !== false
 		) and (
 			// Only if the curly brace belongs to a control structure
-			$control_structure[$curly_braces_count] > 0
+			$control_structure[ $curly_braces_count ] > 0
 		)
 	) --$indent;
 
 	// One additional indentation level for operators at the beginning or the end of a line
-	if ( !$round_braces_count ) {
+	if ( ! $round_braces_count ) {
 
 		static $operators = array(
 			// arithmetic
@@ -1945,20 +1954,20 @@ function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, 
 		);
 
 		if (
-			( isset( $tokens[$key+1] ) and in_array( $tokens[$key+1], $operators ) ) or
-			( isset( $tokens[$key-1] ) and in_array( $tokens[$key-1], $operators ) )
+			( isset( $tokens[ $key + 1 ] ) and in_array( $tokens[ $key + 1 ], $operators ) ) or
+			( isset( $tokens[ $key - 1 ] ) and in_array( $tokens[ $key - 1 ], $operators ) )
 		) {
 			++$indent;
 		} elseif (
-			( isset( $tokens[$key+1] ) and $tokens[$key+1] === "?" ) or
-			( isset( $tokens[$key-1] ) and $tokens[$key-1] === "?" )
+			( isset( $tokens[ $key + 1 ] ) and $tokens[ $key + 1 ] === "?" ) or
+			( isset( $tokens[ $key - 1 ] ) and $tokens[ $key - 1 ] === "?" )
 		) {
 			++$indent;
 			$trinity_started = true;
 		} elseif (
 			$trinity_started and (
-				( isset( $tokens[$key+1] ) and $tokens[$key+1] === ":" ) or
-				( isset( $tokens[$key-1] ) and $tokens[$key-1] === ":" )
+				( isset( $tokens[ $key + 1 ] ) and $tokens[ $key + 1 ] === ":" ) or
+				( isset( $tokens[ $key - 1 ] ) and $tokens[ $key - 1 ] === ":" )
 			)
 		) {
 			++$indent;
@@ -1972,19 +1981,19 @@ function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, 
 	// Indent the current token
 	$text = preg_replace(
 		"/\n[ \t]*/",
-		"\n".$indent_str.( $docblock?" ":"" ),
+		"\n" . $indent_str . ( $docblock?" ":"" ),
 		$text
 	);
 
 	// Cut the indenting at the beginning of the next token
 
 	// End of file reached
-	if ( !isset( $tokens[$key+1] ) ) return;
+	if ( ! isset( $tokens[ $key + 1 ] ) ) return;
 
-	if ( is_string( $tokens[$key+1] ) ) {
-		$text2 =& $tokens[$key+1];
+	if ( is_string( $tokens[ $key + 1 ] ) ) {
+		$text2 = & $tokens[ $key + 1 ];
 	} else {
-		$text2 =& $tokens[$key+1][1];
+		$text2 = & $tokens[ $key + 1 ][1];
 	}
 
 	// Remove indenting at beginning of the the next token
@@ -2000,7 +2009,7 @@ function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, 
 /**
  * Strips indenting before single closing PHP tags
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function strip_closetag_indenting( &$tokens ) {
 
@@ -2009,30 +2018,30 @@ function strip_closetag_indenting( &$tokens ) {
 		if (
 			// T_CLOSE_TAG with following \n
 			$token[0] === T_CLOSE_TAG and
-			substr( $token[1], -1 ) === "\n"
+			substr( $token[1], - 1 ) === "\n"
 		) {
 			if (
 				// T_WHITESPACE or T_COMMENT before with \n at the end
-				isset( $tokens[$key-1] ) and
-				is_array( $tokens[$key-1] ) and
-				( $tokens[$key-1][0] === T_WHITESPACE or $tokens[$key-1][0] === T_COMMENT ) and
-				preg_match( "/\n[ \t]*$/", $tokens[$key-1][1] )
+				isset( $tokens[ $key - 1 ] ) and
+				is_array( $tokens[ $key - 1 ] ) and
+				( $tokens[ $key - 1 ][0] === T_WHITESPACE or $tokens[ $key - 1 ][0] === T_COMMENT ) and
+				preg_match( "/\n[ \t]*$/", $tokens[ $key - 1 ][1] )
 			) {
-				$tokens[$key-1][1] = preg_replace( "/\n[ \t]*$/", "\n", $tokens[$key-1][1] );
+				$tokens[ $key - 1 ][1] = preg_replace( "/\n[ \t]*$/", "\n", $tokens[ $key - 1 ][1] );
 			} elseif (
 				// T_WHITESPACE before without \n
-				isset( $tokens[$key-1] ) and
-				is_array( $tokens[$key-1] ) and
-				$tokens[$key-1][0] === T_WHITESPACE and
-				strpos( $tokens[$key-1][1], "\n" )===false and
+				isset( $tokens[ $key - 1 ] ) and
+				is_array( $tokens[ $key - 1 ] ) and
+				$tokens[ $key - 1 ][0] === T_WHITESPACE and
+				strpos( $tokens[ $key - 1 ][1], "\n" ) === false and
 				// T_WHITESPACE before or T_COMMENT with \n at the end
-				isset( $tokens[$key-2] ) and
-				is_array( $tokens[$key-2] ) and
-				( $tokens[$key-2][0] === T_WHITESPACE or $tokens[$key-2][0] === T_COMMENT ) and
-				preg_match( "/\n[ \t]*$/", $tokens[$key-2][1] )
+				isset( $tokens[ $key - 2 ] ) and
+				is_array( $tokens[ $key - 2 ] ) and
+				( $tokens[ $key - 2 ][0] === T_WHITESPACE or $tokens[ $key - 2 ][0] === T_COMMENT ) and
+				preg_match( "/\n[ \t]*$/", $tokens[ $key - 2 ][1] )
 			) {
-				$tokens[$key-1] = "";
-				$tokens[$key-2][1] = preg_replace( "/\n[ \t]*$/", "\n", $tokens[$key-2][1] );
+				$tokens[ $key - 1 ] = "";
+				$tokens[ $key - 2 ][1] = preg_replace( "/\n[ \t]*$/", "\n", $tokens[ $key - 2 ][1] );
 			}
 		}
 	}
@@ -2048,7 +2057,7 @@ function strip_closetag_indenting( &$tokens ) {
  *
  * Functions inside of curly braces will be ignored.
  *
- * @param string  $content
+ * @param string $content
  * @return array
  */
 function get_functions( &$content ) {
@@ -2065,10 +2074,10 @@ function get_functions( &$content ) {
 		} elseif (
 			$token[0] === T_FUNCTION and
 			$curly_braces_count === 0 and
-			isset( $tokens[$key+2] ) and
-			is_array( $tokens[$key+2] )
+			isset( $tokens[ $key + 2 ] ) and
+			is_array( $tokens[ $key + 2 ] )
 		) {
-			$functions[] = $tokens[$key+2][1];
+			$functions[] = $tokens[ $key + 2 ][1];
 		}
 
 	}
@@ -2080,9 +2089,9 @@ function get_functions( &$content ) {
 /**
  * Gets all defined includes
  *
- * @param array   $seetags (reference)
- * @param string  $content
- * @param string  $file
+ * @param array  $seetags (reference)
+ * @param string $content
+ * @param string $file
  */
 function find_includes( &$seetags, &$content, $file ) {
 
@@ -2091,22 +2100,22 @@ function find_includes( &$seetags, &$content, $file ) {
 	foreach ( $tokens as $key => &$token ) {
 		if ( is_string( $token ) ) continue;
 
-		if ( !in_array( $token[0], array( T_REQUIRE, T_REQUIRE_ONCE, T_INCLUDE, T_INCLUDE_ONCE ) ) ) continue;
+		if ( ! in_array( $token[0], array( T_REQUIRE, T_REQUIRE_ONCE, T_INCLUDE, T_INCLUDE_ONCE ) ) ) continue;
 
 		$t = get_argument_tokens( $tokens, $key );
 		strip_whitespace( $t );
 
 		// Strip round brackets
-		if ( $t[0] === "(" and $t[count( $t )-1] === ")" ) {
-			$t = array_splice( $t, 1, -1 );
+		if ( $t[0] === "(" and $t[count( $t ) - 1] === ")" ) {
+			$t = array_splice( $t, 1, - 1 );
 		}
 
-		if ( !$t ) {
+		if ( ! $t ) {
 			possible_syntax_error( $tokens, $key, "Missing argument" );
 			continue;
 		}
 
-		if ( !is_array( $t[0] ) ) continue;
+		if ( ! is_array( $t[0] ) ) continue;
 
 		// Strip leading docroot variable or constant
 		if (
@@ -2121,12 +2130,12 @@ function find_includes( &$seetags, &$content, $file ) {
 			count( $t ) == 1 and
 			$t[0][0] === T_CONSTANT_ENCAPSED_STRING
 		) {
-			$includedfile = substr( $t[0][1], 1, -1 );
-			$seetags[$includedfile][] = array( $file );
+			$includedfile = substr( $t[0][1], 1, - 1 );
+			$seetags[ $includedfile ][] = array( $file );
 			continue;
 		}
 
-		if ( !$t ) {
+		if ( ! $t ) {
 			possible_syntax_error( $tokens, $key, "String concatenator without following string" );
 		}
 
@@ -2140,22 +2149,22 @@ function find_includes( &$seetags, &$content, $file ) {
  *
  * Existing valid DocTags will be used without change
  *
- * @param string  $text    Content of the DocBlock
- * @param string  $tagname Name of the tag
- * @param array   $tags    All tags to be inserted
+ * @param string $text    Content of the DocBlock
+ * @param string $tagname Name of the tag
+ * @param array  $tags    All tags to be inserted
  * @return string
  */
 function add_doctags_to_doc_comment( $text, $tagname, $tags ) {
 
-	if ( !count( $tags ) ) return $text;
+	if ( ! count( $tags ) ) return $text;
 
 	// Replacement for array_unique()
 	$tagids = array();
 	foreach ( $tags as $key => $tag ) {
-		if ( !in_array( $tag[0], $tagids ) ) {
+		if ( ! in_array( $tag[0], $tagids ) ) {
 			$tagids[] = $tag[0];
 		} else {
-			unset( $tags[$key] );
+			unset( $tags[ $key ] );
 		}
 	}
 
@@ -2167,13 +2176,13 @@ function add_doctags_to_doc_comment( $text, $tagname, $tags ) {
 	foreach ( $lines as $key => $line ) {
 
 		// Add doctags after the last line
-		if ( $key == count( $lines )-1 ) {
+		if ( $key == count( $lines ) - 1 ) {
 			foreach ( $tags as $tag ) {
 				$tagid = $tag[0];
-				if ( isset( $oldtags[$tagid] ) and count( $oldtags[$tagid] ) ) {
+				if ( isset( $oldtags[ $tagid ] ) and count( $oldtags[ $tagid ] ) ) {
 
 					// Use existing line
-					foreach ( $oldtags[$tagid] as $oldtag ) {
+					foreach ( $oldtags[ $tagid ] as $oldtag ) {
 
 						if (
 							$tagname == "param" and
@@ -2188,14 +2197,14 @@ function add_doctags_to_doc_comment( $text, $tagname, $tags ) {
 								isset( $tag[2] ) and
 								substr( $matches[3], 0, strlen( $tag[2] ) ) != $tag[2]
 							) {
-								$matches[3] = $tag[2]." ".$matches[3];
+								$matches[3] = $tag[2] . " " . $matches[3];
 							}
 
-							$newtext .= "* @param ".$tag[1]." ".$tag[0]." ".$matches[3]."\n";
+							$newtext .= "* @param " . $tag[1] . " " . $tag[0] . " " . $matches[3] . "\n";
 
 						} else {
 							// Take old line without changes
-							$newtext .= $oldtag."\n";
+							$newtext .= $oldtag . "\n";
 						}
 
 					}
@@ -2204,26 +2213,26 @@ function add_doctags_to_doc_comment( $text, $tagname, $tags ) {
 
 					// Add new line
 					switch ( $tagname ) {
-					case "param":
+						case "param":
 						if ( empty( $tag[1] ) ) $tag[1] = "unknown";
-						$newtext .= "* @param ".$tag[1]." ".$tag[0].( isset( $tag[2] )?" ".$tag[2]:"" )."\n";
+						$newtext .= "* @param " . $tag[1] . " " . $tag[0] . ( isset( $tag[2] )?" " . $tag[2]:"" ) . "\n";
 						break;
-					case "uses":
-						$newtext .= "* @uses ".$tag[0]."()\n";
+						case "uses":
+						$newtext .= "* @uses " . $tag[0] . "()\n";
 						break;
-					case "return":
+						case "return":
 						$newtext .= "* @return unknown\n";
 						break;
-					case "author":
+						case "author":
 						if ( $GLOBALS['default_author'] ) {
-							$newtext .= "* @author ".$GLOBALS['default_author']."\n";
+							$newtext .= "* @author " . $GLOBALS['default_author'] . "\n";
 						}
 						break;
-					case "package":
-						$newtext .= "* @package ".$GLOBALS['default_package']."\n";
+						case "package":
+						$newtext .= "* @package " . $GLOBALS['default_package'] . "\n";
 						break;
-					case "see":
-						$newtext .= "* @see ".$tag[0]."\n";
+						case "see":
+						$newtext .= "* @see " . $tag[0] . "\n";
 						break;
 					}
 
@@ -2233,17 +2242,17 @@ function add_doctags_to_doc_comment( $text, $tagname, $tags ) {
 		}
 
 		// Match DocTag
-		$regex = '^\s*\*\s+@'.$tagname;
+		$regex = '^\s*\*\s+@' . $tagname;
 		// Match param tag variable
-		if ( $tagname=="param" ) $regex .= '[^\$]*(\$[A-Za-z0-9_]+)';
-		if ( preg_match( '/'.$regex.'/', $line, $matches ) ) {
-			if ( $tagname=="param" ) $oldtags[$matches[1]][] = $line;
+		if ( $tagname == "param" ) $regex .= '[^\$]*(\$[A-Za-z0-9_]+)';
+		if ( preg_match( '/' . $regex . '/', $line, $matches ) ) {
+			if ( $tagname == "param" ) $oldtags[ $matches[1] ][] = $line;
 			else                   $oldtags[""][]          = $line;
 		} else {
 			// Don't change lines without a DocTag
 			$newtext .= $line;
 			// Add a line break after every line except the last
-			if ( $key != count( $lines )-1 ) $newtext.="\n";
+			if ( $key != count( $lines ) - 1 ) $newtext .= "\n";
 		}
 
 	}
@@ -2255,7 +2264,7 @@ function add_doctags_to_doc_comment( $text, $tagname, $tags ) {
 /**
  * Collects the doctags for a function docblock
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  * @return array
  */
 function collect_doctags( &$tokens ) {
@@ -2275,20 +2284,20 @@ function collect_doctags( &$tokens ) {
 			if ( $token === "{" ) {
 				++$curly_braces_count;
 			} elseif ( $token === "}" ) {
-				if ( --$curly_braces_count==0 ) $function = "";
+				if ( --$curly_braces_count == 0 ) $function = "";
 			}
 
 		} else {
 
 			switch ( $token[0] ) {
-			case T_FUNCTION:
+				case T_FUNCTION:
 				// Find function definitions
 
 				$round_braces_count = 0;
 
 				$k = $key + 1;
 
-				if ( is_string( $tokens[$k] ) or $tokens[$k][0] !== T_WHITESPACE ) {
+				if ( is_string( $tokens[ $k ] ) or $tokens[ $k ][0] !== T_WHITESPACE ) {
 					possible_syntax_error( $tokens, $k, "No whitespace found between function keyword and function name" );
 					break;
 				}
@@ -2296,42 +2305,42 @@ function collect_doctags( &$tokens ) {
 				++$k;
 
 				// & before function name
-				if ( $tokens[$k] === "&" ) ++$k;
+				if ( $tokens[ $k ] === "&" ) ++$k;
 
-				if ( is_string( $tokens[$k] ) or $tokens[$k][0] !== T_STRING ) {
+				if ( is_string( $tokens[ $k ] ) or $tokens[ $k ][0] !== T_STRING ) {
 					possible_syntax_error( $tokens, $k, "No string for function name found" );
 					break;
 				}
 
-				$function = $tokens[$k][1];
+				$function = $tokens[ $k ][1];
 				$function_declarations[] = $key;
 
 				// Collect param-doctags
 				$k += 2;
 				// Area between round brackets
 				$reference = false;
-				while ( ( $tokens[$k] != ")" or $round_braces_count ) and $k < count( $tokens ) ) {
-					if ( is_string( $tokens[$k] ) ) {
-						if     ( $tokens[$k] === "(" ) ++$round_braces_count;
-						elseif ( $tokens[$k] === ")" ) --$round_braces_count;
-						elseif ( $tokens[$k] === "&" ) $reference = true;
+				while ( ( $tokens[ $k ] != ")" or $round_braces_count ) and $k < count( $tokens ) ) {
+					if ( is_string( $tokens[ $k ] ) ) {
+						if     ( $tokens[ $k ] === "(" ) ++$round_braces_count;
+						elseif ( $tokens[ $k ] === ")" ) --$round_braces_count;
+						elseif ( $tokens[ $k ] === "&" ) $reference = true;
 					} else {
 						$typehint = false;
 						if (
-							$tokens[$k][0] === T_VARIABLE
+							$tokens[ $k ][0] === T_VARIABLE
 						) {
 							$typehint = "";
 						} elseif (
-							$tokens[$k][0] === T_ARRAY and
-							isset( $tokens[$k+1][0] ) and $tokens[$k+1][0] === T_WHITESPACE and
-							isset( $tokens[$k+2][0] ) and $tokens[$k+2][0] === T_VARIABLE
+							$tokens[ $k ][0] === T_ARRAY and
+							isset( $tokens[ $k + 1 ][0] ) and $tokens[ $k + 1 ][0] === T_WHITESPACE and
+							isset( $tokens[ $k + 2 ][0] ) and $tokens[ $k + 2 ][0] === T_VARIABLE
 						) {
 							$k += 2;
 							$typehint = "array";
 						} elseif (
-							$tokens[$k][0] === T_STRING and
-							isset( $tokens[$k+1][0] ) and $tokens[$k+1][0] === T_WHITESPACE and
-							isset( $tokens[$k+2][0] ) and $tokens[$k+2][0] === T_VARIABLE
+							$tokens[ $k ][0] === T_STRING and
+							isset( $tokens[ $k + 1 ][0] ) and $tokens[ $k + 1 ][0] === T_WHITESPACE and
+							isset( $tokens[ $k + 2 ][0] ) and $tokens[ $k + 2 ][0] === T_VARIABLE
 						) {
 							$k += 2;
 							$typehint = "object";
@@ -2339,9 +2348,9 @@ function collect_doctags( &$tokens ) {
 						if ( $typehint !== false ) {
 							$comments = array();
 							if (
-								( isset( $tokens[$k+1] ) and $tokens[$k+1] === "=" ) or (
-									isset( $tokens[$k+1][0] ) and $tokens[$k+1][0] === T_WHITESPACE and
-									isset( $tokens[$k+2] ) and $tokens[$k+2] === "="
+								( isset( $tokens[ $k + 1 ] ) and $tokens[ $k + 1 ] === "=" ) or (
+									isset( $tokens[ $k + 1 ][0] ) and $tokens[ $k + 1 ][0] === T_WHITESPACE and
+									isset( $tokens[ $k + 2 ] ) and $tokens[ $k + 2 ] === "="
 								)
 							) {
 								$comments[] = "optional";
@@ -2351,37 +2360,37 @@ function collect_doctags( &$tokens ) {
 								$reference = false;
 							}
 							if ( count( $comments ) ) {
-								$comment = "(".join( ", ", $comments ).")";
+								$comment = "(" . join( ", ", $comments ) . ")";
 							} else {
 								$comment = "";
 							}
-							$paramtags[$function][] = array( $tokens[$k][1], $typehint, $comment );
+							$paramtags[ $function ][] = array( $tokens[ $k ][1], $typehint, $comment );
 						}
 					}
 					++$k;
 				}
 				break;
-			case T_CURLY_OPEN:
-			case T_DOLLAR_OPEN_CURLY_BRACES:
+				case T_CURLY_OPEN:
+				case T_DOLLAR_OPEN_CURLY_BRACES:
 				++$curly_braces_count;
 				break;
-			case T_STRING:
+				case T_STRING:
 				// Find function calls
 				if (
-					$tokens[$key+1] === "(" and
-					!in_array( $key-2, $function_declarations ) and
+					$tokens[ $key + 1 ] === "(" and
+					! in_array( $key - 2, $function_declarations ) and
 					in_array( $token[1], $GLOBALS['functions'] )
 				) {
-					$usestags[$function][] = array( $token[1] );
+					$usestags[ $function ][] = array( $token[1] );
 				}
 				break;
-			case T_RETURN:
+				case T_RETURN:
 				// Find returns
 				if (
-					$tokens[$key+1] != ";" and
-					$tokens[$key+2] != ";"
+					$tokens[ $key + 1 ] != ";" and
+					$tokens[ $key + 2 ] != ";"
 				) {
-					$returntags[$function][] = array( "" );
+					$returntags[ $function ][] = array( "" );
 				}
 				break;
 			}
@@ -2397,24 +2406,24 @@ function collect_doctags( &$tokens ) {
 /**
  * Adds file DocBlocks where missing
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function add_file_docblock( &$tokens ) {
 
-	$default_file_docblock = "/**\n".
-		" * ".$GLOBALS['file']."\n".
+	$default_file_docblock = "/**\n" .
+		" * " . $GLOBALS['file'] . "\n" .
 		" *\n";
 	if ( $GLOBALS['default_author'] ) {
-		$default_file_docblock .= " * @author ".$GLOBALS['default_author']."\n";
+		$default_file_docblock .= " * @author " . $GLOBALS['default_author'] . "\n";
 	}
-	$default_file_docblock .= " * @package ".$GLOBALS['default_package']."\n".
+	$default_file_docblock .= " * @package " . $GLOBALS['default_package'] . "\n" .
 		" */";
 
 	// File begins with PHP
 	switch ( $tokens[0][0] ) {
-	case T_OPEN_TAG:
+		case T_OPEN_TAG:
 
-		if ( $GLOBALS['open_tag']=="<?" ) {
+		if ( $GLOBALS['open_tag'] == "<?" ) {
 			if ( $tokens[1][0] === T_WHITESPACE and $tokens[2][0] === T_DOC_COMMENT ) return;
 			// Insert new file docblock after open tag
 			array_splice( $tokens, 0, 1, array(
@@ -2427,19 +2436,19 @@ function add_file_docblock( &$tokens ) {
 			if ( $tokens[1][0] === T_DOC_COMMENT ) return;
 			// Insert new file docblock after open tag
 			array_splice( $tokens, 0, 1, array(
-					array( T_OPEN_TAG, $GLOBALS['open_tag']."\n" ),
+					array( T_OPEN_TAG, $GLOBALS['open_tag'] . "\n" ),
 					array( T_DOC_COMMENT, $default_file_docblock ),
 					array( T_WHITESPACE, "\n" )
 				) );
 		}
 
 		break;
-	case T_INLINE_HTML:
+		case T_INLINE_HTML:
 
 		if ( preg_match( "/^#!\//", $tokens[0][1] ) ) {
 			// File begins with "shebang"-line for direct execution
 
-			if ( $GLOBALS['open_tag']=="<?" ) {
+			if ( $GLOBALS['open_tag'] == "<?" ) {
 				if ( $tokens[2][0] === T_WHITESPACE and $tokens[3][0] === T_DOC_COMMENT ) return;
 				// Insert new file docblock after open tag
 				array_splice( $tokens, 1, 1, array(
@@ -2452,7 +2461,7 @@ function add_file_docblock( &$tokens ) {
 				if ( $tokens[2][0] === T_DOC_COMMENT ) return;
 				// Insert new file docblock after open tag
 				array_splice( $tokens, 1, 1, array(
-						array( T_OPEN_TAG, $GLOBALS['open_tag']."\n" ),
+						array( T_OPEN_TAG, $GLOBALS['open_tag'] . "\n" ),
 						array( T_DOC_COMMENT, $default_file_docblock ),
 						array( T_WHITESPACE, "\n" )
 					) );
@@ -2462,7 +2471,7 @@ function add_file_docblock( &$tokens ) {
 			// File begins with HTML
 
 			// Insert new file docblock in open and close tags at the beginning of the file
-			if ( $GLOBALS['open_tag']=="<?" ) {
+			if ( $GLOBALS['open_tag'] == "<?" ) {
 				array_splice( $tokens, 0, 0, array(
 						array( T_OPEN_TAG, "<?" ),
 						array( T_WHITESPACE, "\n" ),
@@ -2472,7 +2481,7 @@ function add_file_docblock( &$tokens ) {
 					) );
 			} else {
 				array_splice( $tokens, 0, 0, array(
-						array( T_OPEN_TAG, $GLOBALS['open_tag']."\n" ),
+						array( T_OPEN_TAG, $GLOBALS['open_tag'] . "\n" ),
 						array( T_DOC_COMMENT, $default_file_docblock ),
 						array( T_WHITESPACE, "\n\n\n" ),
 						array( T_CLOSE_TAG, "?>\n" )
@@ -2489,7 +2498,7 @@ function add_file_docblock( &$tokens ) {
 /**
  * Adds function DocBlocks where missing
  *
- * @param array   $tokens (reference)
+ * @param array $tokens (reference)
  */
 function add_function_docblocks( &$tokens ) {
 
@@ -2500,34 +2509,34 @@ function add_function_docblocks( &$tokens ) {
 		// Find beginning of the function declaration
 		$k = $key;
 		while (
-			isset( $tokens[$k-1] ) and
-			strpos( token_text( $tokens[$k-1] ), "\n" )===false
+			isset( $tokens[ $k - 1 ] ) and
+			strpos( token_text( $tokens[ $k - 1 ] ), "\n" ) === false
 		) --$k;
 
 		if (
-			!isset( $tokens[$k-2] ) or
-			!is_array( $tokens[$k-2] ) or
-			$tokens[$k-2][0] != T_DOC_COMMENT
+			! isset( $tokens[ $k - 2 ] ) or
+			! is_array( $tokens[ $k - 2 ] ) or
+			$tokens[ $k - 2 ][0] != T_DOC_COMMENT
 		) {
 
 			// Collect old non-phpdoc comments
 			$comment = "";
 			$replace = 0;
 			while (
-				isset( $tokens[$k-1] ) and
-				is_array( $tokens[$k-1] ) and
-				$tokens[$k-1][0] === T_COMMENT
+				isset( $tokens[ $k - 1 ] ) and
+				is_array( $tokens[ $k - 1 ] ) and
+				$tokens[ $k - 1 ][0] === T_COMMENT
 			) {
-				$comment = " * ".trim( ltrim( trim( $tokens[$k-1][1] ), "/#" ) )."\n".$comment;
+				$comment = " * " . trim( ltrim( trim( $tokens[ $k - 1 ][1] ), "/#" ) ) . "\n" . $comment;
 				--$k;
 				++$replace;
 			}
 
-			if ( !$comment ) $comment = " *\n";
+			if ( ! $comment ) $comment = " *\n";
 
 			array_splice( $tokens, $k, $replace, array(
-					array( T_DOC_COMMENT, "/**\n".
-						$comment.
+					array( T_DOC_COMMENT, "/**\n" .
+						$comment .
 						" */" ),
 					array( T_WHITESPACE, "\n" )
 				) );
@@ -2542,11 +2551,11 @@ function add_function_docblocks( &$tokens ) {
 /**
  * Adds DocTags to file or function DocBlocks
  *
- * @param array   $tokens     (reference)
- * @param array   $usetags
- * @param array   $paramtags
- * @param array   $returntags
- * @param array   $seetags
+ * @param array $tokens     (reference)
+ * @param array $usetags
+ * @param array $paramtags
+ * @param array $returntags
+ * @param array $seetags
  */
 function add_doctags( &$tokens, $usetags, $paramtags, $returntags, $seetags ) {
 
@@ -2559,36 +2568,36 @@ function add_doctags( &$tokens, $usetags, $paramtags, $returntags, $seetags ) {
 		if ( $id != T_DOC_COMMENT ) continue;
 
 		$k = $key + 1;
-		while ( in_array( $tokens[$k][0], array( T_WHITESPACE, T_STATIC, T_PUBLIC, T_PROTECTED, T_PRIVATE ) ) ) ++$k;
+		while ( in_array( $tokens[ $k ][0], array( T_WHITESPACE, T_STATIC, T_PUBLIC, T_PROTECTED, T_PRIVATE ) ) ) ++$k;
 
 		if (
-			$tokens[$k][0] === T_FUNCTION and
-			$tokens[$k+1][0] === T_WHITESPACE and
-			$tokens[$k+2][0] === T_STRING
+			$tokens[ $k ][0] === T_FUNCTION and
+			$tokens[ $k + 1 ][0] === T_WHITESPACE and
+			$tokens[ $k + 2 ][0] === T_STRING
 		) {
 
 			// Function DocBlock
-			$f = $tokens[$k+2][1];
-			if ( isset( $paramtags[$f] ) ) {
-				$tokens[$key] = array( $id, add_doctags_to_doc_comment( $tokens[$key][1], "param", $paramtags[$f] ) );
+			$f = $tokens[ $k + 2 ][1];
+			if ( isset( $paramtags[ $f ] ) ) {
+				$tokens[ $key ] = array( $id, add_doctags_to_doc_comment( $tokens[ $key ][1], "param", $paramtags[ $f ] ) );
 			}
-			if ( isset( $returntags[$f] ) ) {
-				$tokens[$key] = array( $id, add_doctags_to_doc_comment( $tokens[$key][1], "return", $returntags[$f] ) );
+			if ( isset( $returntags[ $f ] ) ) {
+				$tokens[ $key ] = array( $id, add_doctags_to_doc_comment( $tokens[ $key ][1], "return", $returntags[ $f ] ) );
 			}
-			if ( isset( $usestags[$f] ) ) {
-				$tokens[$key] = array( $id, add_doctags_to_doc_comment( $tokens[$key][1], "uses", $usestags[$f] ) );
+			if ( isset( $usestags[ $f ] ) ) {
+				$tokens[ $key ] = array( $id, add_doctags_to_doc_comment( $tokens[ $key ][1], "uses", $usestags[ $f ] ) );
 			}
 
-		} elseif ( !$filedocblock ) {
+		} elseif ( ! $filedocblock ) {
 
 			// File DocBlock
 			if ( isset( $usestags[""] ) ) {
-				$tokens[$key] = array( $id, add_doctags_to_doc_comment( $tokens[$key][1], "uses", $usestags[""] ) );
+				$tokens[ $key ] = array( $id, add_doctags_to_doc_comment( $tokens[ $key ][1], "uses", $usestags[""] ) );
 			}
-			$tokens[$key] = array( $id, add_doctags_to_doc_comment( $tokens[$key][1], "author", array( array( "" ) ) ) );
-			$tokens[$key] = array( $id, add_doctags_to_doc_comment( $tokens[$key][1], "package", array( array( "" ) ) ) );
-			if ( isset( $seetags[$GLOBALS['file']] ) ) {
-				$tokens[$key] = array( $id, add_doctags_to_doc_comment( $tokens[$key][1], "see", $seetags[$GLOBALS['file']] ) );
+			$tokens[ $key ] = array( $id, add_doctags_to_doc_comment( $tokens[ $key ][1], "author", array( array( "" ) ) ) );
+			$tokens[ $key ] = array( $id, add_doctags_to_doc_comment( $tokens[ $key ][1], "package", array( array( "" ) ) ) );
+			if ( isset( $seetags[ $GLOBALS['file'] ] ) ) {
+				$tokens[ $key ] = array( $id, add_doctags_to_doc_comment( $tokens[ $key ][1], "see", $seetags[ $GLOBALS['file'] ] ) );
 			}
 
 		}

--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -1859,22 +1859,22 @@ function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, 
 	}
 
 	// One indentation level less for "switch ... case ... default"
-	if (
-		isset( $tokens[$key+1] ) and
-		is_array( $tokens[$key+1] ) and (
-			$tokens[$key+1][0] === T_CASE or
-			$tokens[$key+1][0] === T_DEFAULT or (
-				isset( $tokens[$key+2] ) and
-				is_array( $tokens[$key+2] ) and (
-					$tokens[$key+2][0] === T_CASE or
-					$tokens[$key+2][0] === T_DEFAULT
-				) and
-				// T_WHITESPACE without \n first
-				$tokens[$key+1][0] === T_WHITESPACE and
-				strpos( $tokens[$key+1][1], "\n" )===false
-			)
-		)
-	) --$indent;
+	// if (
+	//  isset( $tokens[ $key+1] ) and
+	//  is_array( $tokens[ $key+1] ) and (
+	//   $tokens[ $key+1][0] === T_CASE or
+	//   $tokens[ $key+1][0] === T_DEFAULT or (
+	//    isset( $tokens[ $key+2] ) and
+	//    is_array( $tokens[ $key+2] ) and (
+	//     $tokens[ $key+2][0] === T_CASE or
+	//     $tokens[ $key+2][0] === T_DEFAULT
+	//    ) and
+	//    // T_WHITESPACE without \n first
+	//    $tokens[ $key+1][0] === T_WHITESPACE and
+	//    strpos( $tokens[ $key+1][1], "\n" )===false
+	//   )
+	//  )
+	// ) --$indent;
 
 	// One indentation level less for an opening curly brace on a seperate line
 	if (

--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -843,10 +843,10 @@ function replace_inline_tabs( &$tokens ) {
 	foreach ( $tokens as &$token ) {
 
 		if ( is_string( $token ) ) {
-			$text = & $token;
+			$text =& $token;
 		} else {
 			if ( token_is_taboo( $token ) ) continue;
-			$text = & $token[1];
+			$text =& $token[1];
 		}
 
 		// Replace one tab with one space
@@ -1281,10 +1281,15 @@ function add_operator_space( &$tokens ) {
 				// The next token is no whitespace
 				! ( isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE )
 			) {
-				// Insert one space after
-				array_splice( $tokens, $key + 1, 0, array(
-						array( T_WHITESPACE, " " )
-					) );
+
+				$by_reference = isset( $tokens[ $key + 1 ] ) && ( '&' === $tokens[ $key + 1 ] );
+
+				if ( ! ( $by_reference && ( '=' === $token ) ) ) {
+					// Insert one space after
+					array_splice( $tokens, $key + 1, 0, array(
+							array( T_WHITESPACE, " " )
+						) );
+				}
 			}
 
 			if (
@@ -1926,11 +1931,11 @@ function indent( &$tokens ) {
 function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, $control_structure, $docblock, &$trinity_started ) {
 
 	if ( is_string( $tokens[ $key ] ) ) {
-		$text = & $tokens[ $key ];
+		$text =& $tokens[ $key ];
 		// If there is no line break it is only a inline string, not involved in indenting
 		if ( strpos( $text, "\n" ) === false ) return;
 	} else {
-		$text = & $tokens[ $key ][1];
+		$text =& $tokens[ $key ][1];
 		// If there is no line break it is only a inline string, not involved in indenting
 		if ( strpos( $text, "\n" ) === false ) return;
 		if ( token_is_taboo( $tokens[ $key ] ) ) return;
@@ -2065,9 +2070,9 @@ function indent_text( &$tokens, $key, $curly_braces_count, $round_braces_count, 
 	if ( ! isset( $tokens[ $key + 1 ] ) ) return;
 
 	if ( is_string( $tokens[ $key + 1 ] ) ) {
-		$text2 = & $tokens[ $key + 1 ];
+		$text2 =& $tokens[ $key + 1 ];
 	} else {
-		$text2 = & $tokens[ $key + 1 ][1];
+		$text2 =& $tokens[ $key + 1 ][1];
 	}
 
 	// Remove indenting at beginning of the the next token

--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -209,8 +209,8 @@ foreach ( $project_files_excludes as $file_exclude ) {
 foreach ( $files as $key => $file ) {
 	// Ignore backups and results from phptidy
 	if (
-		substr( $file, - 12 ) == ".phptidybak~" or
-		substr( $file, - 12 ) == ".phptidy.php"
+		substr( $file, -12 ) == ".phptidybak~" or
+		substr( $file, -12 ) == ".phptidy.php"
 	) {
 		unset( $files[ $key ] );
 		continue;
@@ -475,13 +475,13 @@ function phptidy( $source ) {
 	// Strip trailing whitespace
 	$source = preg_replace( "/[ \t]+\n/", "\n", $source );
 
-	if ( substr( $source, - 1 ) != "\n" ) {
+	if ( substr( $source, -1 ) != "\n" ) {
 		// Add one line break at the end of the file
 		// http://pear.php.net/manual/en/standards.file.php
 		$source .= "\n";
 	} else {
 		// Strip empty lines at the end of the file
-		while ( substr( $source, - 2 ) == "\n\n" ) $source = substr( $source, 0, - 1 );
+		while ( substr( $source, -2 ) == "\n\n" ) $source = substr( $source, 0, -1 );
 	}
 
 	return $source;
@@ -596,7 +596,7 @@ function tokens_rtrim( &$tokens ) {
 		isset( $tokens[ $k = count( $tokens ) - 1 ][0] ) and
 		$tokens[ $k ][0] === T_WHITESPACE
 	) {
-		array_splice( $tokens, - 1 );
+		array_splice( $tokens, -1 );
 	}
 }
 
@@ -1020,7 +1020,7 @@ function fix_statement_brackets( &$tokens ) {
 		}
 
 		// Remove the outermost brackets
-		$tokens_arg = array_slice( $tokens_arg, 1, - 1 );
+		$tokens_arg = array_slice( $tokens_arg, 1, -1 );
 
 		tokens_ltrim( $tokens_arg );
 		tokens_rtrim( $tokens_arg );
@@ -1180,7 +1180,7 @@ function fix_comma_space( &$tokens ) {
 		if ( ! is_string( $token ) ) continue;
 		if (
 			// If the current token ends with a comma...
-			substr( $token, - 1 ) === "," and
+			substr( $token, -1 ) === "," and
 			// ...and the next token is no whitespace
 			! ( isset( $tokens[ $key + 1 ][0] ) and $tokens[ $key + 1 ][0] === T_WHITESPACE )
 		) {
@@ -1301,7 +1301,7 @@ function add_operator_space( &$tokens ) {
 }
 
 /**
- * Returns opening square bracket indexes from tokens.
+ * Returns opening bracket indexes from tokens.
  *
  * Returns the opening brackets for brackets that are empty, or
  * contain a variable or string.
@@ -1417,7 +1417,7 @@ function fix_square_bracket_space( &$tokens ) {
 	$brackets = get_square_brackets( $tokens );
 	$brackets = array_reverse( $brackets, true );
 
-	// Process closing brackets "]".
+	// Process closing brackets "[".
 	foreach ( $brackets as $key => $type ) {
 		if ( ! ( isset( $tokens[ $key ] ) && ( '[' === $tokens[ $key ] ) ) ) {
 			continue;
@@ -1605,7 +1605,7 @@ function fix_docblock_space( &$tokens ) {
 			// Add empty lines before the DocBlock
 			if ( $tokens[ $key - 1 ][0] === T_WHITESPACE ) {
 				$n = 2;
-				if ( substr( token_text( $tokens[ $key - 2 ] ), - 1 ) == "\n" ) --$n;
+				if ( substr( token_text( $tokens[ $key - 2 ] ), -1 ) == "\n" ) --$n;
 				// At least 2 empty lines before the docblock of a function
 				if ( $tokens[ $key + 2 ][0] === T_FUNCTION ) ++$n;
 				if ( strpos( $tokens[ $key - 1 ][1], str_repeat( "\n", $n ) ) === false ) {
@@ -2023,7 +2023,7 @@ function strip_closetag_indenting( &$tokens ) {
 		if (
 			// T_CLOSE_TAG with following \n
 			$token[0] === T_CLOSE_TAG and
-			substr( $token[1], - 1 ) === "\n"
+			substr( $token[1], -1 ) === "\n"
 		) {
 			if (
 				// T_WHITESPACE or T_COMMENT before with \n at the end
@@ -2112,7 +2112,7 @@ function find_includes( &$seetags, &$content, $file ) {
 
 		// Strip round brackets
 		if ( $t[0] === "(" and $t[count( $t ) - 1] === ")" ) {
-			$t = array_splice( $t, 1, - 1 );
+			$t = array_splice( $t, 1, -1 );
 		}
 
 		if ( ! $t ) {
@@ -2135,7 +2135,7 @@ function find_includes( &$seetags, &$content, $file ) {
 			count( $t ) == 1 and
 			$t[0][0] === T_CONSTANT_ENCAPSED_STRING
 		) {
-			$includedfile = substr( $t[0][1], 1, - 1 );
+			$includedfile = substr( $t[0][1], 1, -1 );
 			$seetags[ $includedfile ][] = array( $file );
 			continue;
 		}

--- a/wp-phptidy.php
+++ b/wp-phptidy.php
@@ -1244,6 +1244,7 @@ function fix_docblock_format( &$tokens ) {
 		$doctags_started = false;
 		$last_line = false;
 		$param_max_variable_length = 0;
+		$type_max_variable_length = 0;
 		foreach ( $lines_orig as $line ) {
 			$line = trim( $line );
 			// Strip empty lines
@@ -1282,9 +1283,14 @@ function fix_docblock_format( &$tokens ) {
 						$doctags_started = true;
 					}
 
-					// DocTag format
-					if ( preg_match( '/^\* @param(\s+[^\s\$]*)?\s+(&?\$[^\s]+)/', $line, $matches ) ) {
-						$param_max_variable_length = max( $param_max_variable_length, strlen( $matches[2] ) );
+					// DocTag variable length
+					if ( preg_match( '/^\* @param(\s+[^\s\$]*)?\s+(&?\$[^\s]+)/', $line, $variable ) ) {
+						$param_max_variable_length = max( $param_max_variable_length, strlen( $variable[2] ) );
+					}
+
+					// DocTag type length
+					if ( preg_match( '/^\* @param(\s+([^\s\$]*))?(\s+(&?\$[^\s]+))?(.*)$/', $line, $type ) ) {
+						$type_max_variable_length = max( $type_max_variable_length, strlen( $type[2] ) );
 					}
 
 				}
@@ -1299,9 +1305,15 @@ function fix_docblock_format( &$tokens ) {
 			// DocTag format
 			if ( preg_match( '/^\* @param(\s+([^\s\$]*))?(\s+(&?\$[^\s]+))?(.*)$/', $line, $matches ) ) {
 				$line = "* @param ";
-				if ( $matches[2] ) $line .= str_pad( $matches[2], 7 ); else $line .= "unknown";
+				if ( $matches[2] ) {
+					$line .= str_pad( $matches[2], $type_max_variable_length );
+				} else {
+					$line .= "unknown";
+				}
 				$line .= " ";
-				if ( $matches[4] ) $line .= str_pad( $matches[4], $param_max_variable_length )." ";
+				if ( $matches[4] ) {
+					$line .= str_pad( $matches[4], $param_max_variable_length ) . " ";
+				}
 				$line .= trim( $matches[5] );
 				$lines[$l] = $line;
 			}


### PR DESCRIPTION
This pull request fixes whitespace issues with the  [WordPress Coding Standards for PHP_CodeSniffer](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) rules.

It adds and removes spaces where needed in square brackets and around operators. The `add_operator_space()` formatter was copied from https://github.com/cmrcx/phptidy

Example before:
```php
$array[  'string'  ] = -1;
$array[$key] = true;
$array[$key+1] = ($var*3)-1;
$array[$var[ 'string' ][ 0 ]] = true;
$array[ ] = 'empty square brackets';
$var = trim('string').'concatenated';
if (!($var1===$var2)&&($var2>3)) {
	$var=true;
}
```
And after:
```php
$array['string'] = -1;
$array[ $key ] = true;
$array[ $key + 1 ] = ( $var * 3 ) - 1;
$array[ $var['string'][0] ] = true;
$array[] = 'empty square brackets';
$var = trim( 'string' ) . 'concatenated';
if ( ! ( $var1 === $var2 ) && ( $var2 > 3 ) ) {
	$var = true;
}
```
**DocBlock params**
PhpTidy creates two spaces after the parameter type declaration.
```php
/**
 * @param string  $parameter Parameter.
 */
```

The padding for the type is hardcoded at 7. This PR calculates the real padding needed.

Example before this PR.
In this example there was only one space used between all the types, variables and descriptions. After running PhpTidy the spaces for `$var2`  are not in line with `$variable`.
```php
/**
 * A filter
 *
 * @since 1.0
 *
 * @param WP_Query|array $variable Variable 1.
 * @param int     $var2     Variable 2.
 */
return apply_filters( 'my_filter', $variable, $var2 );
```

Example after running  PhpTidy with this pull request:
```php
/**
 * A filter
 *
 * @since 1.0
 *
 * @param WP_Query|array $variable Variable 1.
 * @param int            $var2     Variable 2.
 */
return apply_filters( 'my_filter', $variable, $var2 );
```
